### PR TITLE
Add support for min_score

### DIFF
--- a/Query.php
+++ b/Query.php
@@ -152,7 +152,11 @@ class Query extends Component implements QueryInterface
      * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-suggesters.html
      */
     public $suggest = [];
-
+    /**
+     * @var float Exclude documents which have a _score less than the minimum specified in min_score
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-min-score.html
+     */
+    public $minScore;
 
     /**
      * @inheritdoc
@@ -512,6 +516,16 @@ class Query extends Component implements QueryInterface
     public function timeout($timeout)
     {
         $this->timeout = $timeout;
+        return $this;
+    }
+
+    /**
+     * @param float $minScore Exclude documents which have a `_score` less than the minimum specified minScore
+     * @return static the query object itself
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-min-score.html
+     */
+    public function minScore($minScore) {
+        $this->minScore = $minScore;
         return $this;
     }
 }

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -74,6 +74,9 @@ class QueryBuilder extends \yii\base\Object
         if ($query->offset > 0) {
             $parts['from'] = (int) $query->offset;
         }
+        if (isset($query->minScore)) {
+            $parts['min_score'] = (float) $query->minScore;
+        }
 
         if (empty($query->query)) {
             $parts['query'] = ["match_all" => (object) []];


### PR DESCRIPTION
Just found that `min_score` was missing from Query. `min_score` can be useful if you want to exclude documents which have a `_score` less than a minimum threshold.

See: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-min-score.html

Example usage:
```
$query->minScore(0.5);
```
