### PR TITLE
Elasticsearch site moved to elastic.co [ci skip]

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -23,7 +23,7 @@ use yii\helpers\StringHelper;
  * ActiveRecord is the base class for classes representing relational data in terms of objects.
  *
  * This class implements the ActiveRecord pattern for the fulltext search and data storage
- * [elasticsearch](http://www.elasticsearch.org/).
+ * [elasticsearch](https://www.elastic.co/).
  *
  * For defining a record a subclass should at least implement the [[attributes()]] method to define
  * attributes.
@@ -112,7 +112,7 @@ class ActiveRecord extends BaseActiveRecord
      * @param mixed $primaryKey the primaryKey value
      * @param array $options options given in this parameter are passed to elasticsearch
      * as request URI parameters.
-     * Please refer to the [elasticsearch documentation](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-get.html)
+     * Please refer to the [elasticsearch documentation](http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html)
      * for more details on these options.
      * @return static|null The record instance or null if it was not found.
      */
@@ -141,7 +141,7 @@ class ActiveRecord extends BaseActiveRecord
      * @param array $options options given in this parameter are passed to elasticsearch
      * as request URI parameters.
      *
-     * Please refer to the [elasticsearch documentation](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-get.html)
+     * Please refer to the [elasticsearch documentation](http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html)
      * for more details on these options.
      * @return array The record instances, or empty array if nothing was found
      */
@@ -170,9 +170,9 @@ class ActiveRecord extends BaseActiveRecord
         return $models;
     }
 
-    // TODO add more like this feature http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-more-like-this.html
+    // TODO add more like this feature http://www.elastic.co/guide/en/elasticsearch/reference/current/search-more-like-this.html
 
-    // TODO add percolate functionality http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-percolate.html
+    // TODO add percolate functionality http://www.elastic.co/guide/en/elasticsearch/reference/current/search-percolate.html
 
     // TODO implement copy and move as pk change is not possible
 
@@ -247,7 +247,7 @@ class ActiveRecord extends BaseActiveRecord
      * ActiveRecord attributes so you should never add `_id` to the list of [[attributes()|attributes]].
      *
      * You may override this method to define the primary key name when you have defined
-     * [path mapping](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-id-field.html)
+     * [path mapping](http://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html)
      * for the `_id` field so that it is part of the `_source` and thus part of the [[attributes()|attributes]].
      *
      * Note that elasticsearch only supports _one_ attribute to be the primary key. However to match the signature
@@ -268,7 +268,7 @@ class ActiveRecord extends BaseActiveRecord
      *
      * Attributes are names of fields of the corresponding elasticsearch document.
      * The primaryKey for elasticsearch documents is the `_id` field by default which is not part of the attributes.
-     * You may define [path mapping](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-id-field.html)
+     * You may define [path mapping](http://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html)
      * for the `_id` field so that it is part of the `_source` fields and thus becomes part of the attributes.
      *
      * @return string[] list of attribute names.
@@ -386,7 +386,7 @@ class ActiveRecord extends BaseActiveRecord
      *
      * If the [[primaryKey|primary key]] is not set (null) during insertion,
      * it will be populated with a
-     * [randomly generated value](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-index_.html#_automatic_id_generation)
+     * [randomly generated value](http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_automatic_id_generation)
      * after insertion.
      *
      * For example, to insert a customer record:
@@ -409,7 +409,7 @@ class ActiveRecord extends BaseActiveRecord
      * - `parent` by giving the primaryKey of another record this defines a parent-child relation
      * - `timestamp` specifies the timestamp to store along with the document. Default is indexing time.
      *
-     * Please refer to the [elasticsearch documentation](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-index_.html)
+     * Please refer to the [elasticsearch documentation](http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html)
      * for more details on these options.
      *
      * By default the `op_type` is set to `create`.
@@ -466,14 +466,14 @@ class ActiveRecord extends BaseActiveRecord
      * - `refresh` refresh the relevant primary and replica shards (not the whole index) immediately after the operation occurs, so that the updated document appears in search results immediately.
      * - `detect_noop` this parameter will become part of the request body and will prevent the index from getting updated when nothing has changed.
      *
-     * Please refer to the [elasticsearch documentation](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-update.html#_parameters_3)
+     * Please refer to the [elasticsearch documentation](http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html#_parameters_3)
      * for more details on these options.
      *
      * The following parameters are Yii specific:
      *
      * - `optimistic_locking` set this to `true` to enable optimistic locking, avoid updating when the record has changed since it
      *   has been loaded from the database. Yii will set the `version` parameter to the value stored in [[version]].
-     *   See the [elasticsearch documentation](http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html) for details.
+     *   See the [elasticsearch documentation](http://www.elastic.co/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html) for details.
      *
      *   Make sure the record has been fetched with a [[version]] before. This is only the case
      *   for records fetched via [[get()]] and [[mget()]] by default. For normal queries, the `_version` field has to be fetched explicitly.
@@ -532,7 +532,7 @@ class ActiveRecord extends BaseActiveRecord
             );
         } catch(Exception $e) {
             // HTTP 409 is the response in case of failed optimistic locking
-            // http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html
+            // http://www.elastic.co/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html
             if (isset($e->errorInfo['responseCode']) && $e->errorInfo['responseCode'] == 409) {
                 throw new StaleObjectException('The object being updated is outdated.', $e->errorInfo, $e->getCode(), $e);
             }
@@ -695,14 +695,14 @@ class ActiveRecord extends BaseActiveRecord
      * - `consistency` the write consistency of the index/delete operation.
      * - `refresh` refresh the relevant primary and replica shards (not the whole index) immediately after the operation occurs, so that the updated document appears in search results immediately.
      *
-     * Please refer to the [elasticsearch documentation](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete.html)
+     * Please refer to the [elasticsearch documentation](http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html)
      * for more details on these options.
      *
      * The following parameters are Yii specific:
      *
      * - `optimistic_locking` set this to `true` to enable optimistic locking, avoid updating when the record has changed since it
      *   has been loaded from the database. Yii will set the `version` parameter to the value stored in [[version]].
-     *   See the [elasticsearch documentation](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete.html#delete-versioning) for details.
+     *   See the [elasticsearch documentation](http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html#delete-versioning) for details.
      *
      *   Make sure the record has been fetched with a [[version]] before. This is only the case
      *   for records fetched via [[get()]] and [[mget()]] by default. For normal queries, the `_version` field has to be fetched explicitly.
@@ -734,7 +734,7 @@ class ActiveRecord extends BaseActiveRecord
             );
         } catch(Exception $e) {
             // HTTP 409 is the response in case of failed optimistic locking
-            // http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html
+            // http://www.elastic.co/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html
             if (isset($e->errorInfo['responseCode']) && $e->errorInfo['responseCode'] == 409) {
                 throw new StaleObjectException('The object being deleted is outdated.', $e->errorInfo, $e->getCode(), $e);
             }
@@ -813,7 +813,7 @@ class ActiveRecord extends BaseActiveRecord
     /**
      * This method has no effect in Elasticsearch ActiveRecord.
      *
-     * Elasticsearch ActiveRecord uses [native Optimistic locking](http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html).
+     * Elasticsearch ActiveRecord uses [native Optimistic locking](http://www.elastic.co/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html).
      * See [[update()]] for more details.
      */
     public function optimisticLock()

--- a/Command.php
+++ b/Command.php
@@ -14,7 +14,7 @@ use yii\helpers\Json;
 /**
  * The Command class implements the API for accessing the elasticsearch REST API.
  *
- * Check the [elasticsearch guide](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/index.html)
+ * Check the [elasticsearch guide](http://www.elastic.co/guide/en/elasticsearch/reference/current/index.html)
  * for details on these commands.
  *
  * @author Carsten Brandt <mail@cebe.cc>
@@ -28,7 +28,7 @@ class Command extends Component
     public $db;
     /**
      * @var string|array the indexes to execute the query on. Defaults to null meaning all indexes
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search.html#search-multi-index
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html#search-multi-index-type
      */
     public $index;
     /**
@@ -96,7 +96,7 @@ class Command extends Component
      * @param string|array $suggester the suggester body
      * @param array $options
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-suggesters.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html
      */
     public function suggest($suggester, $options = [])
     {
@@ -122,7 +122,7 @@ class Command extends Component
      * @param null $id the documents id. If not specified Id will be automatically chosen
      * @param array $options
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-index_.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html
      */
     public function insert($index, $type, $data, $id = null, $options = [])
     {
@@ -146,7 +146,7 @@ class Command extends Component
      * @param $id
      * @param array $options
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-get.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html
      */
     public function get($index, $type, $id, $options = [])
     {
@@ -162,7 +162,7 @@ class Command extends Component
      * @param $ids
      * @param array $options
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-multi-get.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html
      */
     public function mget($index, $type, $ids, $options = [])
     {
@@ -177,7 +177,7 @@ class Command extends Component
      * @param $type
      * @param $id
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-get.html#_source
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html#_source
      */
     public function getSource($index, $type, $id)
     {
@@ -190,7 +190,7 @@ class Command extends Component
      * @param $type
      * @param $id
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-get.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html
      */
     public function exists($index, $type, $id)
     {
@@ -204,7 +204,7 @@ class Command extends Component
      * @param $id
      * @param array $options
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html
      */
     public function delete($index, $type, $id, $options = [])
     {
@@ -218,7 +218,7 @@ class Command extends Component
      * @param $id
      * @param array $options
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-update.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html
      */
     public function update($index, $type, $id, $data, $options = [])
     {
@@ -233,14 +233,14 @@ class Command extends Component
         return $this->db->post([$index, $type, $id, '_update'], $options, Json::encode($body));
     }
 
-    // TODO bulk http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html
+    // TODO bulk http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
 
     /**
      * creates an index
      * @param $index
      * @param array $configuration
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-create-index.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html
      */
     public function createIndex($index, $configuration = null)
     {
@@ -253,7 +253,7 @@ class Command extends Component
      * deletes an index
      * @param $index
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-delete-index.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-index.html
      */
     public function deleteIndex($index)
     {
@@ -263,7 +263,7 @@ class Command extends Component
     /**
      * deletes all indexes
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-delete-index.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-index.html
      */
     public function deleteAllIndexes()
     {
@@ -274,7 +274,7 @@ class Command extends Component
      * checks whether an index exists
      * @param $index
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-exists.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-exists.html
      */
     public function indexExists($index)
     {
@@ -285,24 +285,24 @@ class Command extends Component
      * @param $index
      * @param $type
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-types-exists.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-types-exists.html
      */
     public function typeExists($index, $type)
     {
         return $this->db->head([$index, $type]);
     }
 
-    // TODO http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-aliases.html
+    // TODO http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
 
-    // TODO http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-update-settings.html
-    // TODO http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-get-settings.html
+    // TODO http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html
+    // TODO http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-settings.html
 
-    // TODO http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-warmers.html
+    // TODO http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-warmers.html
 
     /**
      * @param $index
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-open-close.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html
      */
     public function openIndex($index)
     {
@@ -312,7 +312,7 @@ class Command extends Component
     /**
      * @param $index
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-open-close.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html
      */
     public function closeIndex($index)
     {
@@ -322,20 +322,20 @@ class Command extends Component
     /**
      * @param $index
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-status.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-status.html
      */
     public function getIndexStatus($index = '_all')
     {
         return $this->db->get([$index, '_status']);
     }
 
-    // TODO http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-stats.html
-    // http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-segments.html
+    // TODO http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-stats.html
+    // http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-segments.html
 
     /**
      * @param $index
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-clearcache.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-clearcache.html
      */
     public function clearIndexCache($index)
     {
@@ -345,7 +345,7 @@ class Command extends Component
     /**
      * @param $index
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-flush.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-flush.html
      */
     public function flushIndex($index = '_all')
     {
@@ -355,23 +355,23 @@ class Command extends Component
     /**
      * @param $index
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-refresh.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html
      */
     public function refreshIndex($index)
     {
         return $this->db->post([$index, '_refresh']);
     }
 
-    // TODO http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-optimize.html
+    // TODO http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-optimize.html
 
-    // TODO http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-gateway-snapshot.html
+    // TODO http://www.elastic.co/guide/en/elasticsearch/reference/0.90/indices-gateway-snapshot.html
 
     /**
      * @param $index
      * @param $type
      * @param $mapping
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-put-mapping.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html
      */
     public function setMapping($index, $type, $mapping, $options = [])
     {
@@ -384,7 +384,7 @@ class Command extends Component
      * @param string $index
      * @param string $type
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-get-mapping.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-mapping.html
      */
     public function getMapping($index = '_all', $type = '_all')
     {
@@ -395,7 +395,7 @@ class Command extends Component
      * @param $index
      * @param $type
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-put-mapping.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html
      */
     public function deleteMapping($index, $type)
     {
@@ -406,7 +406,7 @@ class Command extends Component
      * @param $index
      * @param string $type
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-get-field-mapping.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-field-mapping.html
      */
 //    public function getFieldMapping($index, $type = '_all')
 //    {
@@ -418,7 +418,7 @@ class Command extends Component
      * @param $options
      * @param $index
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-analyze.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html
      */
 //	public function analyze($options, $index = null)
 //	{
@@ -433,7 +433,7 @@ class Command extends Component
      * @param $mappings
      * @param integer $order
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-templates.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
      */
     public function createTemplate($name, $pattern, $settings, $mappings, $order = 0)
     {
@@ -451,7 +451,7 @@ class Command extends Component
     /**
      * @param $name
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-templates.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
      */
     public function deleteTemplate($name)
     {
@@ -462,7 +462,7 @@ class Command extends Component
     /**
      * @param $name
      * @return mixed
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-templates.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
      */
     public function getTemplate($name)
     {

--- a/Connection.php
+++ b/Connection.php
@@ -37,7 +37,7 @@ class Connection extends Component
     /**
      * @var array cluster nodes
      * This is populated with the result of a cluster nodes request when [[autodetectCluster]] is true.
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-nodes-info.html#cluster-nodes-info
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html#cluster-nodes-info
      */
     public $nodes = [
         ['http_address' => 'inet[/127.0.0.1:9200]'],
@@ -46,7 +46,7 @@ class Connection extends Component
      * @var array the active node. key of [[nodes]]. Will be randomly selected on [[open()]].
      */
     public $activeNode;
-    // TODO http://www.elasticsearch.org/guide/en/elasticsearch/client/php-api/current/_configuration.html#_example_configuring_http_basic_auth
+    // TODO http://www.elastic.co/guide/en/elasticsearch/client/php-api/current/_configuration.html#_host_configuration
     public $auth = [];
     /**
      * @var float timeout to use for connecting to an elasticsearch node.

--- a/Query.php
+++ b/Query.php
@@ -82,11 +82,11 @@ class Query extends Component implements QueryInterface
      *
      * > Note: Field values are [always returned as arrays] even if they only have one value.
      *
-     * [always returned as arrays]: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/_return_values.html#_return_values
-     * [script field]: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-script-fields.html
+     * [always returned as arrays]: http://www.elastic.co/guide/en/elasticsearch/reference/1.x/_return_values.html#_return_values
+     * [script field]: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-script-fields.html
      *
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-fields.html#search-request-fields
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-script-fields.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-fields.html#search-request-fields
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-script-fields.html
      * @see fields()
      * @see source
      */
@@ -97,7 +97,7 @@ class Query extends Component implements QueryInterface
      * If not set, it means retrieving the full `_source` field unless [[fields]] are specified.
      * Setting this option to `false` will disable return of the `_source` field, this means that only the primaryKey
      * of a record will be available in the result.
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-source-filtering.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-source-filtering.html
      * @see source()
      * @see fields
      */
@@ -118,38 +118,38 @@ class Query extends Component implements QueryInterface
      * @var integer A search timeout, bounding the search request to be executed within the specified time value
      * and bail with the hits accumulated up to that point when expired. Defaults to no timeout.
      * @see timeout()
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html#_parameters_3
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#_parameters_5
      */
     public $timeout;
     /**
      * @var array|string The query part of this search query. This is an array or json string that follows the format of
-     * the elasticsearch [Query DSL](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html).
+     * the elasticsearch [Query DSL](http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html).
      */
     public $query;
     /**
      * @var array|string The filter part of this search query. This is an array or json string that follows the format of
-     * the elasticsearch [Query DSL](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html).
+     * the elasticsearch [Query DSL](http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html).
      */
     public $filter;
     /**
      * @var array The highlight part of this search query. This is an array that allows to highlight search results
      * on one or more fields.
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-highlighting.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/1.x/search-request-highlighting.html
      */
     public $highlight;
     /**
      * @var array List of aggregations to add to this query.
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-aggregations.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/1.x/search-aggregations.html
      */
     public $aggregations = [];
     /**
      * @var array the 'stats' part of the query. An array of groups to maintain a statistics aggregation for.
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search.html#stats-groups
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search.html#stats-groups
      */
     public $stats = [];
     /**
      * @var array list of suggesters to add to this query.
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-suggesters.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html
      */
     public $suggest = [];
 
@@ -161,7 +161,7 @@ class Query extends Component implements QueryInterface
     {
         parent::init();
         // setting the default limit according to elasticsearch defaults
-        // http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html#_parameters_3
+        // http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#_parameters_5
         if ($this->limit === null) {
             $this->limit = 10;
         }
@@ -238,8 +238,8 @@ class Query extends Component implements QueryInterface
      * If this parameter is not given, the `elasticsearch` application component will be used.
      * @param array $options The options given with this query. Possible options are:
      *
-     *  - [routing](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search.html#search-routing)
-     *  - [search_type](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-search-type.html)
+     *  - [routing](http://www.elastic.co/guide/en/elasticsearch/reference/current/search.html#search-routing)
+     *  - [search_type](http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-search-type.html)
      *
      * @return array the query results.
      */
@@ -261,7 +261,7 @@ class Query extends Component implements QueryInterface
         return $result;
     }
 
-    // TODO add scroll/scan http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-search-type.html#scan
+    // TODO add scroll/scan http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-search-type.html#scan
 
     /**
      * Executes the query and deletes all matching documents.
@@ -341,8 +341,8 @@ class Query extends Component implements QueryInterface
     {
         // TODO consider sending to _count api instead of _search for performance
         // only when no facety are registerted.
-        // http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-count.html
-        // http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/_search_requests.html
+        // http://www.elastic.co/guide/en/elasticsearch/reference/current/search-count.html
+        // http://www.elastic.co/guide/en/elasticsearch/reference/1.x/_search_requests.html
 
         $options = [];
         $options['search_type'] = 'count';
@@ -365,7 +365,7 @@ class Query extends Component implements QueryInterface
      * Adds a 'stats' part to the query.
      * @param array $groups an array of groups to maintain a statistics aggregation for.
      * @return static the query object itself
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search.html#stats-groups
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search.html#stats-groups
      */
     public function stats($groups)
     {
@@ -377,7 +377,7 @@ class Query extends Component implements QueryInterface
      * Sets a highlight parameters to retrieve from the documents.
      * @param array $highlight array of parameters to highlight results.
      * @return static the query object itself
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-highlighting.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html
      */
     public function highlight($highlight)
     {
@@ -391,7 +391,7 @@ class Query extends Component implements QueryInterface
      * @param string $type the aggregation type. e.g. `terms`, `range`, `histogram`...
      * @param string|array $options the configuration options for this aggregation. Can be an array or a json string.
      * @return static the query object itself
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-aggregations.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/1.x/search-aggregations.html
      */
     public function addAggregation($name, $type, $options)
     {
@@ -408,7 +408,7 @@ class Query extends Component implements QueryInterface
      * @param string $type the aggregation type. e.g. `terms`, `range`, `histogram`...
      * @param string|array $options the configuration options for this aggregation. Can be an array or a json string.
      * @return static the query object itself
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-aggregations.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/1.x/search-aggregations.html
      */
     public function addAgg($name, $type, $options)
     {
@@ -420,7 +420,7 @@ class Query extends Component implements QueryInterface
      * @param string $name the name of the suggester
      * @param string|array $definition the configuration options for this suggester. Can be an array or a json string.
      * @return static the query object itself
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-suggesters.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html
      */
     public function addSuggester($name, $definition)
     {
@@ -428,9 +428,9 @@ class Query extends Component implements QueryInterface
         return $this;
     }
 
-    // TODO add validate query http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-validate.html
+    // TODO add validate query http://www.elastic.co/guide/en/elasticsearch/reference/current/search-validate.html
 
-    // TODO support multi query via static method http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-multi-search.html
+    // TODO support multi query via static method http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html
 
     /**
      * Sets the querypart of this search query.
@@ -461,7 +461,7 @@ class Query extends Component implements QueryInterface
      * @param string|array $type The type to retrieve data from. This can be a string representing a single type
      * or a an array of multiple types. If this is `null` it means that all types are being queried.
      * @return static the query object itself
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-search.html#search-multi-index-type
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html#search-multi-index-type
      */
     public function from($index, $type = null)
     {
@@ -474,7 +474,7 @@ class Query extends Component implements QueryInterface
      * Sets the fields to retrieve from the documents.
      * @param array $fields the fields to be selected.
      * @return static the query object itself
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-fields.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-fields.html
      */
     public function fields($fields)
     {
@@ -490,7 +490,7 @@ class Query extends Component implements QueryInterface
      * Sets the source filtering, specifying how the `_source` field of the document should be returned.
      * @param array $source the source patterns to be selected.
      * @return static the query object itself
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-source-filtering.html
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-source-filtering.html
      */
     public function source($source)
     {
@@ -507,7 +507,7 @@ class Query extends Component implements QueryInterface
      * @param integer $timeout A search timeout, bounding the search request to be executed within the specified time value
      * and bail with the hits accumulated up to that point when expired. Defaults to no timeout.
      * @return static the query object itself
-     * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html#_parameters_3
+     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#_parameters_5
      */
     public function timeout($timeout)
     {

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -149,7 +149,7 @@ class QueryBuilder extends \yii\base\Object
                 $column = '_uid';
             }
 
-            // allow elasticsearch extended syntax as described in http://www.elasticsearch.org/guide/reference/api/search/sort/
+            // allow elasticsearch extended syntax as described in http://www.elastic.co/guide/en/elasticsearch/guide/master/_sorting.html
             if (is_array($direction)) {
                 $orders[] = [$column => $direction];
             } else {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Elasticsearch Query and ActiveRecord for Yii 2
 ==============================================
 
-This extension provides the [elasticsearch](http://www.elasticsearch.org/) integration for the [Yii framework 2.0](http://www.yiiframework.com).
+This extension provides the [elasticsearch](https://www.elastic.co/) integration for the [Yii framework 2.0](http://www.yiiframework.com).
 It includes basic querying/search support and also implements the `ActiveRecord` pattern that allows you to store active
 records in elasticsearch.
 

--- a/docs/guide-ja/README.md
+++ b/docs/guide-ja/README.md
@@ -1,7 +1,7 @@
 Yii 2.0 elasticsearch エクステンション
 ======================================
 
-このエクステンションは、Yii 2 フレームワークに対する [elasticsearch](http://www.elasticsearch.org/) の統合を提供します。
+このエクステンションは、Yii 2 フレームワークに対する [elasticsearch](https://www.elastic.co/) の統合を提供します。
 基本的なクエリや検索をサポートするとともに、`ActiveRecord` パターンを実装して、アクティブレコードを elasticsearch に保存することを可能にしています。
 
 始めよう

--- a/docs/guide-ja/usage-ar.md
+++ b/docs/guide-ja/usage-ar.md
@@ -1,33 +1,33 @@
-ï¿½Aï¿½Nï¿½eï¿½Bï¿½uï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ï¿½gï¿½ï¿½
+ƒAƒNƒeƒBƒuƒŒƒR[ƒh‚ğg‚¤
 ========================
 
-Yii ï¿½ÌƒAï¿½Nï¿½eï¿½Bï¿½uï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½Ìgï¿½pï¿½ï¿½@ï¿½ÉŠÖ‚ï¿½ï¿½ï¿½ï¿½Ê“Iï¿½Èï¿½ï¿½É‚Â‚ï¿½ï¿½Ä‚ÍA[ï¿½Kï¿½Cï¿½h](https://github.com/yiisoft/yii2/blob/master/docs/guide/db-active-record.md) ï¿½ï¿½ï¿½Qï¿½Æ‚ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½B
+Yii ‚ÌƒAƒNƒeƒBƒuƒŒƒR[ƒh‚Ìg—p•û–@‚ÉŠÖ‚·‚éˆê”Ê“I‚Èî•ñ‚É‚Â‚¢‚Ä‚ÍA[ƒKƒCƒh](https://github.com/yiisoft/yii2/blob/master/docs/guide/db-active-record.md) ‚ğQÆ‚µ‚Ä‚­‚¾‚³‚¢B
 
-Elasticsearch ï¿½ÌƒAï¿½Nï¿½eï¿½Bï¿½uï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ï¿½`ï¿½ï¿½ï¿½é‚½ï¿½ß‚É‚ÍAï¿½ï¿½ï¿½È‚ï¿½ï¿½Ìƒï¿½ï¿½Rï¿½[ï¿½hï¿½Nï¿½ï¿½ï¿½Xï¿½ï¿½ [[yii\elasticsearch\ActiveRecord]] ï¿½ï¿½ï¿½ï¿½gï¿½ï¿½ï¿½ï¿½ï¿½ÄAï¿½Å’ï¿½ï¿½ï¿½Aï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½Ì‘ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½`ï¿½ï¿½ï¿½é‚½ï¿½ß‚ï¿½ [[yii\elasticsearch\ActiveRecord::attributes()|attributes()]] ï¿½ï¿½ï¿½\ï¿½bï¿½hï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Kï¿½vï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
-Elasticsearch ï¿½Å‚Íƒvï¿½ï¿½ï¿½Cï¿½}ï¿½ï¿½ï¿½Lï¿½[ï¿½Ìˆï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Êï¿½ÆˆÙ‚È‚ï¿½Ü‚ï¿½ï¿½B
-ï¿½Æ‚ï¿½ï¿½ï¿½ï¿½Ì‚ÍAï¿½vï¿½ï¿½ï¿½Cï¿½}ï¿½ï¿½ï¿½Lï¿½[ (elasticsearch ï¿½Ì—pï¿½ï¿½Å‚ï¿½ `_id` ï¿½tï¿½Bï¿½[ï¿½ï¿½ï¿½h) ï¿½ï¿½ï¿½Aï¿½fï¿½tï¿½Hï¿½ï¿½ï¿½gï¿½Å‚Í‘ï¿½ï¿½ï¿½ï¿½Ì‚ï¿½ï¿½ï¿½ï¿½É“ï¿½ï¿½È‚ï¿½ï¿½ï¿½ï¿½ï¿½Å‚ï¿½ï¿½B
-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½A`_id` ï¿½tï¿½Bï¿½[ï¿½ï¿½ï¿½hï¿½ğ‘®ï¿½ï¿½ÉŠÜ‚ß‚é‚½ï¿½ß‚ï¿½ [ï¿½pï¿½Xï¿½}ï¿½bï¿½sï¿½ï¿½ï¿½O](http://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html) ï¿½ï¿½ï¿½`ï¿½ï¿½ï¿½é‚±ï¿½Æ‚Íoï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
-ï¿½pï¿½Xï¿½}ï¿½bï¿½sï¿½ï¿½ï¿½Oï¿½Ì’ï¿½`ï¿½Ìdï¿½ï¿½É‚Â‚ï¿½ï¿½Ä‚ÍA[elasticsearch ï¿½Ìƒhï¿½Lï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½g](http://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html) ï¿½ï¿½ï¿½Qï¿½Æ‚ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½B
-document ï¿½Ü‚ï¿½ï¿½ï¿½ record ï¿½ï¿½ `_id` ï¿½tï¿½Bï¿½[ï¿½ï¿½ï¿½hï¿½ÍA[[yii\elasticsearch\ActiveRecord::getPrimaryKey()|getPrimaryKey()]] ï¿½ï¿½ï¿½ï¿½ï¿½ [[yii\elasticsearch\ActiveRecord::setPrimaryKey()|setPrimaryKey()]] ï¿½ï¿½ï¿½gï¿½ï¿½ï¿½ÄƒAï¿½Nï¿½Zï¿½Xï¿½ï¿½ï¿½é‚±ï¿½Æ‚ï¿½ï¿½oï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
-ï¿½pï¿½Xï¿½}ï¿½bï¿½sï¿½ï¿½ï¿½Oï¿½ï¿½ï¿½ï¿½`ï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ê‡ï¿½ÍA[[yii\elasticsearch\ActiveRecord::primaryKey()|primaryKey()]] ï¿½ï¿½ï¿½\ï¿½bï¿½hï¿½ï¿½ï¿½gï¿½ï¿½ï¿½Ä‘ï¿½ï¿½ï¿½ï¿½Ì–ï¿½ï¿½Oï¿½ï¿½ï¿½`ï¿½ï¿½ï¿½é‚±ï¿½Æ‚ï¿½ï¿½oï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
+Elasticsearch ‚ÌƒAƒNƒeƒBƒuƒŒƒR[ƒh‚ğ’è‹`‚·‚é‚½‚ß‚É‚ÍA‚ ‚È‚½‚ÌƒŒƒR[ƒhƒNƒ‰ƒX‚ğ [[yii\elasticsearch\ActiveRecord]] ‚©‚çŠg’£‚µ‚ÄAÅ’áŒÀAƒŒƒR[ƒh‚Ì‘®«‚ğ’è‹`‚·‚é‚½‚ß‚Ì [[yii\elasticsearch\ActiveRecord::attributes()|attributes()]] ƒƒ\ƒbƒh‚ğÀ‘•‚·‚é•K—v‚ª‚ ‚è‚Ü‚·B
+Elasticsearch ‚Å‚Íƒvƒ‰ƒCƒ}ƒŠƒL[‚Ìˆµ‚¢‚ª’Êí‚ÆˆÙ‚È‚è‚Ü‚·B
+‚Æ‚¢‚¤‚Ì‚ÍAƒvƒ‰ƒCƒ}ƒŠƒL[ (elasticsearch ‚Ì—pŒê‚Å‚Í `_id` ƒtƒB[ƒ‹ƒh) ‚ªAƒfƒtƒHƒ‹ƒg‚Å‚Í‘®«‚Ì‚¤‚¿‚É“ü‚ç‚È‚¢‚©‚ç‚Å‚·B
+‚½‚¾‚µA`_id` ƒtƒB[ƒ‹ƒh‚ğ‘®«‚ÉŠÜ‚ß‚é‚½‚ß‚Ì [ƒpƒXƒ}ƒbƒsƒ“ƒO](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-id-field.html) ‚ğ’è‹`‚·‚é‚±‚Æ‚Ío—ˆ‚Ü‚·B
+ƒpƒXƒ}ƒbƒsƒ“ƒO‚Ì’è‹`‚Ìd•û‚É‚Â‚¢‚Ä‚ÍA[elasticsearch ‚ÌƒhƒLƒ…ƒƒ“ƒg](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-id-field.html) ‚ğQÆ‚µ‚Ä‚­‚¾‚³‚¢B
+document ‚Ü‚½‚Í record ‚Ì `_id` ƒtƒB[ƒ‹ƒh‚ÍA[[yii\elasticsearch\ActiveRecord::getPrimaryKey()|getPrimaryKey()]] ‚¨‚æ‚Ñ [[yii\elasticsearch\ActiveRecord::setPrimaryKey()|setPrimaryKey()]] ‚ğg‚Á‚ÄƒAƒNƒZƒX‚·‚é‚±‚Æ‚ªo—ˆ‚Ü‚·B
+ƒpƒXƒ}ƒbƒsƒ“ƒO‚ª’è‹`‚³‚ê‚Ä‚¢‚éê‡‚ÍA[[yii\elasticsearch\ActiveRecord::primaryKey()|primaryKey()]] ƒƒ\ƒbƒh‚ğg‚Á‚Ä‘®«‚Ì–¼‘O‚ğ’è‹`‚·‚é‚±‚Æ‚ªo—ˆ‚Ü‚·B
 
-ï¿½È‰ï¿½ï¿½ï¿½ `Customer` ï¿½ÆŒÄ‚Î‚ï¿½éƒ‚ï¿½fï¿½ï¿½ï¿½Ì—ï¿½Å‚ï¿½ï¿½B
+ˆÈ‰º‚Í `Customer` ‚ÆŒÄ‚Î‚ê‚éƒ‚ƒfƒ‹‚Ì—á‚Å‚·B
 
 ```php
 class Customer extends \yii\elasticsearch\ActiveRecord
 {
     /**
-     * @return array ï¿½ï¿½ï¿½Ìƒï¿½ï¿½Rï¿½[ï¿½hï¿½Ì‘ï¿½ï¿½ï¿½ï¿½Ìƒï¿½ï¿½Xï¿½g
+     * @return array ‚±‚ÌƒŒƒR[ƒh‚Ì‘®«‚ÌƒŠƒXƒg
      */
     public function attributes()
     {
-        // '_id' ï¿½É‘Î‚ï¿½ï¿½ï¿½pï¿½Xï¿½}ï¿½bï¿½sï¿½ï¿½ï¿½Ois setup to field 'id'
+        // '_id' ‚É‘Î‚·‚éƒpƒXƒ}ƒbƒsƒ“ƒOis setup to field 'id'
         return ['id', 'name', 'address', 'registration_date'];
     }
 
     /**
-     * @return ActiveQuery Order ï¿½ï¿½ï¿½Rï¿½[ï¿½h ï¿½Ö‚Ìƒï¿½ï¿½ï¿½ï¿½[ï¿½Vï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½`
-     * (Order ï¿½Í‘ï¿½ï¿½Ìƒfï¿½[ï¿½^ï¿½xï¿½[ï¿½Xï¿½Aï¿½á‚¦ï¿½ÎAredis ï¿½ï¿½Êï¿½ï¿½ SQLDB ï¿½É‚ï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½Ç‚ï¿½)
+     * @return ActiveQuery Order ƒŒƒR[ƒh ‚Ö‚ÌƒŠƒŒ[ƒVƒ‡ƒ“‚ğ’è‹`
+     * (Order ‚Í‘¼‚Ìƒf[ƒ^ƒx[ƒXA—á‚¦‚ÎAredis ‚â’Êí‚Ì SQLDB ‚É‚ ‚Á‚Ä‚à—Ç‚¢)
      */
     public function getOrders()
     {
@@ -35,7 +35,7 @@ class Customer extends \yii\elasticsearch\ActiveRecord
     }
 
     /**
-     * `$query` ï¿½ï¿½ï¿½Cï¿½ï¿½ï¿½ï¿½ï¿½ÄƒAï¿½Nï¿½eï¿½Bï¿½u (status = 1) ï¿½ÈŒÚ‹qï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ô‚ï¿½ï¿½Xï¿½Rï¿½[ï¿½vï¿½ï¿½ï¿½`
+     * `$query` ‚ğC³‚µ‚ÄƒAƒNƒeƒBƒu (status = 1) ‚ÈŒÚ‹q‚¾‚¯‚ğ•Ô‚·ƒXƒR[ƒv‚ğ’è‹`
      */
     public static function active($query)
     {
@@ -44,61 +44,61 @@ class Customer extends \yii\elasticsearch\ActiveRecord
 }
 ```
 
-[[yii\elasticsearch\ActiveRecord::index()|index()]] ï¿½ï¿½ [[yii\elasticsearch\ActiveRecord::type()|type()]] ï¿½ï¿½ï¿½Iï¿½[ï¿½oï¿½[ï¿½ï¿½ï¿½Cï¿½hï¿½ï¿½ï¿½ÄAï¿½ï¿½ï¿½Ìƒï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ï¿½\ï¿½ï¿½ï¿½Cï¿½ï¿½ï¿½fï¿½bï¿½Nï¿½Xï¿½Æƒ^ï¿½Cï¿½vï¿½ï¿½ï¿½`ï¿½ï¿½ï¿½é‚±ï¿½Æ‚ï¿½ï¿½oï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
+[[yii\elasticsearch\ActiveRecord::index()|index()]] ‚Æ [[yii\elasticsearch\ActiveRecord::type()|type()]] ‚ğƒI[ƒo[ƒ‰ƒCƒh‚µ‚ÄA‚±‚ÌƒŒƒR[ƒh‚ª•\‚·ƒCƒ“ƒfƒbƒNƒX‚Æƒ^ƒCƒv‚ğ’è‹`‚·‚é‚±‚Æ‚ªo—ˆ‚Ü‚·B
 
-elasticsearch ï¿½ÌƒAï¿½Nï¿½eï¿½Bï¿½uï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½Ìˆï¿½Ê“Iï¿½Ègï¿½pï¿½ï¿½@ï¿½ÍA[ï¿½Kï¿½Cï¿½h](https://github.com/yiisoft/yii2/blob/master/docs/guide/active-record.md) ï¿½Åï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ê‚½ï¿½fï¿½[ï¿½^ï¿½xï¿½[ï¿½Xï¿½ÌƒAï¿½Nï¿½eï¿½Bï¿½uï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½Ìê‡ï¿½Æ”ï¿½ï¿½É‚æ‚­ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½Ü‚ï¿½ï¿½B
-ï¿½È‰ï¿½ï¿½Ìï¿½ï¿½ï¿½ï¿½ÆŠgï¿½ï¿½ (*!*) ï¿½ï¿½ï¿½ï¿½ï¿½é‚±ï¿½Æ‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ÎAï¿½ï¿½ï¿½ï¿½ï¿½Cï¿½ï¿½ï¿½^ï¿½[ï¿½tï¿½Fï¿½Cï¿½Xï¿½Æ‹@ï¿½\ï¿½ï¿½ï¿½Tï¿½|ï¿½[ï¿½gï¿½ï¿½ï¿½Ä‚ï¿½ï¿½Ü‚ï¿½ï¿½B
+elasticsearch ‚ÌƒAƒNƒeƒBƒuƒŒƒR[ƒh‚Ìˆê”Ê“I‚Èg—p•û–@‚ÍA[ƒKƒCƒh](https://github.com/yiisoft/yii2/blob/master/docs/guide/active-record.md) ‚Åà–¾‚³‚ê‚½ƒf[ƒ^ƒx[ƒX‚ÌƒAƒNƒeƒBƒuƒŒƒR[ƒh‚Ìê‡‚Æ”ñí‚É‚æ‚­—‚Ä‚¢‚Ü‚·B
+ˆÈ‰º‚Ì§ŒÀ‚ÆŠg’£ (*!*) ‚ª‚ ‚é‚±‚Æ‚ğœ‚¯‚ÎA“¯‚¶ƒCƒ“ƒ^[ƒtƒFƒCƒX‚Æ‹@”\‚ğƒTƒ|[ƒg‚µ‚Ä‚¢‚Ü‚·B
 
-- elasticsearch ï¿½ï¿½ SQL ï¿½ï¿½ï¿½Tï¿½|ï¿½[ï¿½gï¿½ï¿½ï¿½Ä‚ï¿½ï¿½È‚ï¿½ï¿½ï¿½ï¿½ßAï¿½Nï¿½Gï¿½ï¿½ï¿½ï¿½ API ï¿½ï¿½ `join()`ï¿½A`groupBy()`ï¿½A`having()` ï¿½ï¿½ï¿½ï¿½ï¿½ `union()` ï¿½ï¿½ï¿½Tï¿½|ï¿½[ï¿½gï¿½ï¿½ï¿½Ü‚ï¿½ï¿½ï¿½B
-  ï¿½ï¿½ï¿½×‘Ö‚ï¿½ï¿½Aï¿½ï¿½ï¿½~ï¿½bï¿½gï¿½Aï¿½Iï¿½tï¿½Zï¿½bï¿½gï¿½Aï¿½ï¿½ï¿½ï¿½ï¿½tï¿½ï¿½ WHERE ï¿½ÍAï¿½ï¿½ï¿½×‚ÄƒTï¿½|ï¿½[ï¿½gï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½Ü‚ï¿½ï¿½B
-- [[yii\elasticsearch\ActiveQuery::from()|from()]] ï¿½Íƒeï¿½[ï¿½uï¿½ï¿½ï¿½ï¿½Iï¿½ï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½ï¿½B
-  ï¿½ï¿½ï¿½ï¿½ï¿½Å‚Í‚È‚ï¿½ï¿½Aï¿½Nï¿½Gï¿½ï¿½ï¿½ÎÛ‚ï¿½ [ï¿½Cï¿½ï¿½ï¿½fï¿½bï¿½Nï¿½X](http://www.elastic.co/guide/en/elasticsearch/reference/current/glossary.html#glossary-index) ï¿½ï¿½ [ï¿½^ï¿½Cï¿½v](http://www.elastic.co/guide/en/elasticsearch/reference/current/glossary.html#glossary-type) ï¿½ï¿½Iï¿½ï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
-- `select()` ï¿½ï¿½ [[yii\elasticsearch\ActiveQuery::fields()|fields()]] ï¿½É’uï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½Ü‚ï¿½ï¿½B
-  ï¿½ï¿½{ï¿½Iï¿½É‚Í“ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Æ‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ì‚Å‚ï¿½ï¿½ï¿½ï¿½A`fields` ï¿½Ì•ï¿½ elasticsearch ï¿½Ì—pï¿½ï¿½Æ‚ï¿½ï¿½Ä‘ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Å‚ï¿½ï¿½å‚¤ï¿½B
-  ï¿½hï¿½Lï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½gï¿½ï¿½ï¿½ï¿½æ“¾ï¿½ï¿½ï¿½ï¿½tï¿½Bï¿½[ï¿½ï¿½ï¿½hï¿½ï¿½ï¿½`ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
-- Elasticsearch ï¿½É‚Íƒeï¿½[ï¿½uï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½ï¿½Ì‚ÅAï¿½eï¿½[ï¿½uï¿½ï¿½ï¿½ï¿½Ê‚ï¿½ï¿½Ä‚ï¿½ [[yii\elasticsearch\ActiveQuery::via()|via]] ï¿½ï¿½ï¿½ï¿½ï¿½[ï¿½Vï¿½ï¿½ï¿½ï¿½ï¿½Í’ï¿½`ï¿½ï¿½ï¿½é‚±ï¿½Æ‚ï¿½ï¿½oï¿½ï¿½ï¿½Ü‚ï¿½ï¿½ï¿½B
-- Elasticsearch ï¿½Íƒfï¿½[ï¿½^ï¿½Xï¿½gï¿½ï¿½ï¿½[ï¿½Wï¿½Å‚ï¿½ï¿½ï¿½Æ“ï¿½ï¿½ï¿½ï¿½ÉŒï¿½ï¿½ï¿½ï¿½Gï¿½ï¿½ï¿½Wï¿½ï¿½ï¿½Å‚ï¿½ï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½Ì‚ÅAï¿½ï¿½ï¿½Rï¿½È‚ï¿½ï¿½ï¿½Aï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½ÌŒï¿½ï¿½ï¿½ï¿½É‘Î‚ï¿½ï¿½ï¿½Tï¿½|ï¿½[ï¿½gï¿½ï¿½ï¿½Ç‰ï¿½ï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½Ü‚ï¿½ï¿½B
-  Elasticsearch ï¿½ÌƒNï¿½Gï¿½ï¿½ï¿½ï¿½ï¿½\ï¿½ï¿½ï¿½ï¿½ï¿½é‚½ï¿½ß‚ï¿½ [[yii\elasticsearch\ActiveQuery::query()|query()]]ï¿½A[[yii\elasticsearch\ActiveQuery::filter()|filter()]] ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ [[yii\elasticsearch\ActiveQuery::addFacet()|addFacet()]] ï¿½Æ‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½\ï¿½bï¿½hï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
-  ï¿½ï¿½ï¿½ï¿½ç‚ªï¿½Ç‚Ì‚æ‚¤ï¿½É“ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½É‚Â‚ï¿½ï¿½ÄAï¿½ï¿½ï¿½Ìgï¿½pï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½B
-  ï¿½Ü‚ï¿½ï¿½A`query` ï¿½ï¿½ `filter` ï¿½Ì•ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½\ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½@ï¿½É‚Â‚ï¿½ï¿½Ä‚ÍA[Query DSL](http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html) ï¿½ï¿½ï¿½Qï¿½Æ‚ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½B
-- Elasticsearch ï¿½ÌƒAï¿½Nï¿½eï¿½Bï¿½uï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ï¿½ï¿½Êï¿½ÌƒAï¿½Nï¿½eï¿½Bï¿½uï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½Nï¿½ï¿½ï¿½Xï¿½Ö‚Ìƒï¿½ï¿½ï¿½ï¿½[ï¿½Vï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½`ï¿½ï¿½ï¿½é‚±ï¿½Æ‚ï¿½ï¿½Â”\ï¿½Å‚ï¿½ï¿½Bï¿½Ü‚ï¿½ï¿½Aï¿½ï¿½ï¿½Ì‹tï¿½ï¿½ï¿½Â”\ï¿½Å‚ï¿½ï¿½B
+- elasticsearch ‚Í SQL ‚ğƒTƒ|[ƒg‚µ‚Ä‚¢‚È‚¢‚½‚ßAƒNƒGƒŠ‚Ì API ‚Í `join()`A`groupBy()`A`having()` ‚¨‚æ‚Ñ `union()` ‚ğƒTƒ|[ƒg‚µ‚Ü‚¹‚ñB
+  •À‚×‘Ö‚¦AƒŠƒ~ƒbƒgAƒIƒtƒZƒbƒgAğŒ•t‚« WHERE ‚ÍA‚·‚×‚ÄƒTƒ|[ƒg‚³‚ê‚Ä‚¢‚Ü‚·B
+- [[yii\elasticsearch\ActiveQuery::from()|from()]] ‚Íƒe[ƒuƒ‹‚ğ‘I‘ğ‚µ‚Ü‚¹‚ñB
+  ‚»‚¤‚Å‚Í‚È‚­AƒNƒGƒŠ‘ÎÛ‚Ì [ƒCƒ“ƒfƒbƒNƒX](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/glossary.html#glossary-index) ‚Æ [ƒ^ƒCƒv](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/glossary.html#glossary-type) ‚ğ‘I‘ğ‚µ‚Ü‚·B
+- `select()` ‚Í [[yii\elasticsearch\ActiveQuery::fields()|fields()]] ‚É’u‚«Š·‚¦‚ç‚ê‚Ä‚¢‚Ü‚·B
+  Šî–{“I‚É‚Í“¯‚¶‚±‚Æ‚ğ‚·‚é‚à‚Ì‚Å‚·‚ªA`fields` ‚Ì•û‚ª elasticsearch ‚Ì—pŒê‚Æ‚µ‚Ä‘Š‰‚µ‚¢‚Å‚µ‚å‚¤B
+  ƒhƒLƒ…ƒƒ“ƒg‚©‚çæ“¾‚·‚éƒtƒB[ƒ‹ƒh‚ğ’è‹`‚µ‚Ü‚·B
+- Elasticsearch ‚É‚Íƒe[ƒuƒ‹‚ª‚ ‚è‚Ü‚¹‚ñ‚Ì‚ÅAƒe[ƒuƒ‹‚ğ’Ê‚¶‚Ä‚Ì [[yii\elasticsearch\ActiveQuery::via()|via]] ƒŠƒŒ[ƒVƒ‡ƒ“‚Í’è‹`‚·‚é‚±‚Æ‚ªo—ˆ‚Ü‚¹‚ñB
+- Elasticsearch ‚Íƒf[ƒ^ƒXƒgƒŒ[ƒW‚Å‚ ‚é‚Æ“¯‚ÉŒŸõƒGƒ“ƒWƒ“‚Å‚à‚ ‚è‚Ü‚·‚Ì‚ÅA“–‘R‚È‚ª‚çAƒŒƒR[ƒh‚ÌŒŸõ‚É‘Î‚·‚éƒTƒ|[ƒg‚ª’Ç‰Á‚³‚ê‚Ä‚¢‚Ü‚·B
+  Elasticsearch ‚ÌƒNƒGƒŠ‚ğ\¬‚·‚é‚½‚ß‚Ì [[yii\elasticsearch\ActiveQuery::query()|query()]]A[[yii\elasticsearch\ActiveQuery::filter()|filter()]] ‚»‚µ‚Ä [[yii\elasticsearch\ActiveQuery::addFacet()|addFacet()]] ‚Æ‚¢‚¤ƒƒ\ƒbƒh‚ª‚ ‚è‚Ü‚·B
+  ‚±‚ê‚ç‚ª‚Ç‚Ì‚æ‚¤‚É“­‚­‚©‚É‚Â‚¢‚ÄA‰º‚Ìg—p—á‚ğŒ©‚Ä‚­‚¾‚³‚¢B
+  ‚Ü‚½A`query` ‚Æ `filter` ‚Ì•”•ª‚ğ\¬‚·‚é•û–@‚É‚Â‚¢‚Ä‚ÍA[Query DSL](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html) ‚ğQÆ‚µ‚Ä‚­‚¾‚³‚¢B
+- Elasticsearch ‚ÌƒAƒNƒeƒBƒuƒŒƒR[ƒh‚©‚ç’Êí‚ÌƒAƒNƒeƒBƒuƒŒƒR[ƒhƒNƒ‰ƒX‚Ö‚ÌƒŠƒŒ[ƒVƒ‡ƒ“‚ğ’è‹`‚·‚é‚±‚Æ‚à‰Â”\‚Å‚·B‚Ü‚½A‚»‚Ì‹t‚à‰Â”\‚Å‚·B
 
-> Note|**ï¿½ï¿½ï¿½ï¿½**: ï¿½fï¿½tï¿½Hï¿½ï¿½ï¿½gï¿½Å‚ÍAelasticsearch ï¿½ÍAï¿½Ç‚ï¿½ÈƒNï¿½Gï¿½ï¿½ï¿½Å‚ï¿½ï¿½Aï¿½Ô‚ï¿½ï¿½ï¿½éƒŒï¿½Rï¿½[ï¿½hï¿½Ìï¿½ï¿½ï¿½ 10 ï¿½ÉŒï¿½ï¿½è‚µï¿½Ä‚ï¿½ï¿½Ü‚ï¿½ï¿½B
-> ï¿½ï¿½ï¿½ï¿½ï¿½Æ‘ï¿½ï¿½ï¿½ï¿½Ìƒï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ï¿½æ“¾ï¿½ï¿½ï¿½é‚±ï¿½Æ‚ï¿½ï¿½ï¿½Ò‚ï¿½ï¿½ï¿½ê‡ï¿½ÍAï¿½ï¿½ï¿½ï¿½ï¿½[ï¿½Vï¿½ï¿½ï¿½ï¿½ï¿½Ì’ï¿½`ï¿½Åï¿½ï¿½ï¿½ğ–¾ï¿½ï¿½Iï¿½Éwï¿½è‚µï¿½È‚ï¿½ï¿½ï¿½Î‚È‚ï¿½Ü‚ï¿½ï¿½ï¿½B
-> ï¿½ï¿½ï¿½Ì‚ï¿½ï¿½Æ‚ÍAvia() ï¿½ï¿½ï¿½gï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½[ï¿½Vï¿½ï¿½ï¿½ï¿½ï¿½É‚Æ‚ï¿½ï¿½Ä‚ï¿½ï¿½dï¿½vï¿½Å‚ï¿½ï¿½B
-> ï¿½È‚ï¿½ï¿½È‚ï¿½Avia ï¿½Ìƒï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ 10 ï¿½Ü‚Å‚Éï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ê‡ï¿½ÍAï¿½ï¿½ï¿½ï¿½ï¿½[ï¿½Vï¿½ï¿½ï¿½ï¿½ï¿½Ìƒï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ 10 ï¿½ğ’´‚ï¿½ï¿½é‚±ï¿½Æ‚Íoï¿½ï¿½ï¿½È‚ï¿½ï¿½ï¿½ï¿½ï¿½Å‚ï¿½ï¿½B
+> Note|**’ˆÓ**: ƒfƒtƒHƒ‹ƒg‚Å‚ÍAelasticsearch ‚ÍA‚Ç‚ñ‚ÈƒNƒGƒŠ‚Å‚àA•Ô‚³‚ê‚éƒŒƒR[ƒh‚Ì”‚ğ 10 ‚ÉŒÀ’è‚µ‚Ä‚¢‚Ü‚·B
+> ‚à‚Á‚Æ‘½‚­‚ÌƒŒƒR[ƒh‚ğæ“¾‚·‚é‚±‚Æ‚ğŠú‘Ò‚·‚éê‡‚ÍAƒŠƒŒ[ƒVƒ‡ƒ“‚Ì’è‹`‚ÅãŒÀ‚ğ–¾¦“I‚Éw’è‚µ‚È‚¯‚ê‚Î‚È‚è‚Ü‚¹‚ñB
+> ‚±‚Ì‚±‚Æ‚ÍAvia() ‚ğg‚¤ƒŠƒŒ[ƒVƒ‡ƒ“‚É‚Æ‚Á‚Ä‚àd—v‚Å‚·B
+> ‚È‚º‚È‚çAvia ‚ÌƒŒƒR[ƒh‚ª 10 ‚Ü‚Å‚É§ŒÀ‚³‚ê‚Ä‚¢‚éê‡‚ÍAƒŠƒŒ[ƒVƒ‡ƒ“‚ÌƒŒƒR[ƒh‚à 10 ‚ğ’´‚¦‚é‚±‚Æ‚Ío—ˆ‚È‚¢‚©‚ç‚Å‚·B
 
 
-ï¿½gï¿½pï¿½ï¿½:
+g—p—á:
 
 ```php
 $customer = new Customer();
-$customer->primaryKey = 1; // ï¿½ï¿½ï¿½Ìê‡ï¿½ÍA$customer->id = 1 ï¿½Æ“ï¿½ï¿½ï¿½
+$customer->primaryKey = 1; // ‚±‚Ìê‡‚ÍA$customer->id = 1 ‚Æ“™‰¿
 $customer->attributes = ['name' => 'test'];
 $customer->save();
 
-$customer = Customer::get(1); // PK ï¿½É‚ï¿½ï¿½ï¿½Äƒï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ï¿½æ“¾
-$customers = Customer::mget([1,2,3]); // PK ï¿½É‚ï¿½ï¿½ï¿½Ä•ï¿½ï¿½ï¿½ï¿½Ìƒï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ï¿½æ“¾
-$customer = Customer::find()->where(['name' => 'test'])->one(); // ï¿½Nï¿½Gï¿½ï¿½ï¿½É‚ï¿½ï¿½æ“¾ï¿½Bï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½ğ³‚ï¿½ï¿½ï¿½ï¿½æ“¾ï¿½ï¿½ï¿½é‚½ï¿½ß‚É‚Í‚ï¿½ï¿½Ìƒtï¿½Bï¿½[ï¿½ï¿½ï¿½hï¿½Éƒ}ï¿½bï¿½sï¿½ï¿½ï¿½Oï¿½ï¿½ï¿½\ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Kï¿½vï¿½ï¿½ï¿½ï¿½ï¿½é‚±ï¿½Æ‚É’ï¿½ï¿½ÓB
-$customers = Customer::find()->active()->all(); // ï¿½Nï¿½Gï¿½ï¿½ï¿½É‚ï¿½ï¿½ï¿½Ä‘Sï¿½Ä‚ï¿½ï¿½æ“¾ (`active` ï¿½Xï¿½Rï¿½[ï¿½vï¿½ï¿½ï¿½gï¿½ï¿½ï¿½ï¿½)
+$customer = Customer::get(1); // PK ‚É‚æ‚Á‚ÄƒŒƒR[ƒh‚ğæ“¾
+$customers = Customer::mget([1,2,3]); // PK ‚É‚æ‚Á‚Ä•¡”‚ÌƒŒƒR[ƒh‚ğæ“¾
+$customer = Customer::find()->where(['name' => 'test'])->one(); // ƒNƒGƒŠ‚É‚æ‚éæ“¾BƒŒƒR[ƒh‚ğ³‚µ‚­æ“¾‚·‚é‚½‚ß‚É‚Í‚±‚ÌƒtƒB[ƒ‹ƒh‚Éƒ}ƒbƒsƒ“ƒO‚ğ\¬‚·‚é•K—v‚ª‚ ‚é‚±‚Æ‚É’ˆÓB
+$customers = Customer::find()->active()->all(); // ƒNƒGƒŠ‚É‚æ‚Á‚Ä‘S‚Ä‚ğæ“¾ (`active` ƒXƒR[ƒv‚ğg‚Á‚Ä)
 
-// http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
+// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
 $result = Article::find()->query(["match" => ["title" => "yii"]])->all(); // articles whose title contains "yii"
 
-// http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-flt-query.html
+// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-flt-query.html
 $query = Article::find()->query([
     "fuzzy_like_this" => [
         "fields" => ["title", "description"],
-        "like_text" => "ï¿½ï¿½ï¿½ÌƒNï¿½Gï¿½ï¿½ï¿½ÍAï¿½ï¿½ï¿½Ìƒeï¿½Lï¿½Xï¿½gï¿½Éï¿½ï¿½ï¿½ï¿½Lï¿½ï¿½ï¿½ï¿½Ô‚ï¿½ï¿½Ü‚ï¿½ :-)",
+        "like_text" => "‚±‚ÌƒNƒGƒŠ‚ÍA‚±‚ÌƒeƒLƒXƒg‚É—‚½‹L–‚ğ•Ô‚µ‚Ü‚· :-)",
         "max_query_terms" => 12
     ]
 ]);
 
-$query->all(); // ï¿½Sï¿½Ä‚Ìƒhï¿½Lï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½gï¿½ï¿½ï¿½æ“¾
-// ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ facets ï¿½ï¿½Ç‰ï¿½ï¿½Å‚ï¿½ï¿½ï¿½
+$query->all(); // ‘S‚Ä‚ÌƒhƒLƒ…ƒƒ“ƒg‚ğæ“¾
+// ŒŸõ‚É facets ‚ğ’Ç‰Á‚Å‚«‚é
 $query->addStatisticalFacet('click_stats', ['field' => 'visit_count']);
-$query->search(); // ï¿½Sï¿½Ä‚Ìƒï¿½ï¿½Rï¿½[ï¿½hï¿½Aï¿½ï¿½ï¿½ï¿½ÑAvisit_count ï¿½tï¿½Bï¿½[ï¿½ï¿½ï¿½hï¿½ÉŠÖ‚ï¿½ï¿½é“ï¿½v (ï¿½á‚¦ï¿½ÎAï¿½ï¿½ï¿½ÏAï¿½ï¿½ï¿½vï¿½Aï¿½Åï¿½ï¿½Aï¿½Å‘ï¿½È‚ï¿½) ï¿½ï¿½ï¿½æ“¾
+$query->search(); // ‘S‚Ä‚ÌƒŒƒR[ƒhA‚¨‚æ‚ÑAvisit_count ƒtƒB[ƒ‹ƒh‚ÉŠÖ‚·‚é“Œv (—á‚¦‚ÎA•½‹ÏA‡ŒvAÅ¬AÅ‘å‚È‚Ç) ‚ğæ“¾
 ```
 
-ï¿½ï¿½ï¿½ï¿½ï¿½ÄAï¿½Ü‚ï¿½ï¿½Aï¿½ï¿½ï¿½ë‚¢ï¿½ï¿½Æ‘ï¿½Rï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
-"it's endless what you can build"[?](https://www.elastic.co/)
+‚»‚µ‚ÄA‚Ü‚¾A‚¢‚ë‚¢‚ë‚Æ‘òR‚ ‚è‚Ü‚·B
+"it's endless what you can build"[?](http://www.elasticsearch.org/)

--- a/docs/guide-ja/usage-ar.md
+++ b/docs/guide-ja/usage-ar.md
@@ -1,33 +1,33 @@
-ƒAƒNƒeƒBƒuƒŒƒR[ƒh‚ğg‚¤
+ï¿½Aï¿½Nï¿½eï¿½Bï¿½uï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ï¿½gï¿½ï¿½
 ========================
 
-Yii ‚ÌƒAƒNƒeƒBƒuƒŒƒR[ƒh‚Ìg—p•û–@‚ÉŠÖ‚·‚éˆê”Ê“I‚Èî•ñ‚É‚Â‚¢‚Ä‚ÍA[ƒKƒCƒh](https://github.com/yiisoft/yii2/blob/master/docs/guide/db-active-record.md) ‚ğQÆ‚µ‚Ä‚­‚¾‚³‚¢B
+Yii ï¿½ÌƒAï¿½Nï¿½eï¿½Bï¿½uï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½Ìgï¿½pï¿½ï¿½@ï¿½ÉŠÖ‚ï¿½ï¿½ï¿½ï¿½Ê“Iï¿½Èï¿½ï¿½É‚Â‚ï¿½ï¿½Ä‚ÍA[ï¿½Kï¿½Cï¿½h](https://github.com/yiisoft/yii2/blob/master/docs/guide/db-active-record.md) ï¿½ï¿½ï¿½Qï¿½Æ‚ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½B
 
-Elasticsearch ‚ÌƒAƒNƒeƒBƒuƒŒƒR[ƒh‚ğ’è‹`‚·‚é‚½‚ß‚É‚ÍA‚ ‚È‚½‚ÌƒŒƒR[ƒhƒNƒ‰ƒX‚ğ [[yii\elasticsearch\ActiveRecord]] ‚©‚çŠg’£‚µ‚ÄAÅ’áŒÀAƒŒƒR[ƒh‚Ì‘®«‚ğ’è‹`‚·‚é‚½‚ß‚Ì [[yii\elasticsearch\ActiveRecord::attributes()|attributes()]] ƒƒ\ƒbƒh‚ğÀ‘•‚·‚é•K—v‚ª‚ ‚è‚Ü‚·B
-Elasticsearch ‚Å‚Íƒvƒ‰ƒCƒ}ƒŠƒL[‚Ìˆµ‚¢‚ª’Êí‚ÆˆÙ‚È‚è‚Ü‚·B
-‚Æ‚¢‚¤‚Ì‚ÍAƒvƒ‰ƒCƒ}ƒŠƒL[ (elasticsearch ‚Ì—pŒê‚Å‚Í `_id` ƒtƒB[ƒ‹ƒh) ‚ªAƒfƒtƒHƒ‹ƒg‚Å‚Í‘®«‚Ì‚¤‚¿‚É“ü‚ç‚È‚¢‚©‚ç‚Å‚·B
-‚½‚¾‚µA`_id` ƒtƒB[ƒ‹ƒh‚ğ‘®«‚ÉŠÜ‚ß‚é‚½‚ß‚Ì [ƒpƒXƒ}ƒbƒsƒ“ƒO](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-id-field.html) ‚ğ’è‹`‚·‚é‚±‚Æ‚Ío—ˆ‚Ü‚·B
-ƒpƒXƒ}ƒbƒsƒ“ƒO‚Ì’è‹`‚Ìd•û‚É‚Â‚¢‚Ä‚ÍA[elasticsearch ‚ÌƒhƒLƒ…ƒƒ“ƒg](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-id-field.html) ‚ğQÆ‚µ‚Ä‚­‚¾‚³‚¢B
-document ‚Ü‚½‚Í record ‚Ì `_id` ƒtƒB[ƒ‹ƒh‚ÍA[[yii\elasticsearch\ActiveRecord::getPrimaryKey()|getPrimaryKey()]] ‚¨‚æ‚Ñ [[yii\elasticsearch\ActiveRecord::setPrimaryKey()|setPrimaryKey()]] ‚ğg‚Á‚ÄƒAƒNƒZƒX‚·‚é‚±‚Æ‚ªo—ˆ‚Ü‚·B
-ƒpƒXƒ}ƒbƒsƒ“ƒO‚ª’è‹`‚³‚ê‚Ä‚¢‚éê‡‚ÍA[[yii\elasticsearch\ActiveRecord::primaryKey()|primaryKey()]] ƒƒ\ƒbƒh‚ğg‚Á‚Ä‘®«‚Ì–¼‘O‚ğ’è‹`‚·‚é‚±‚Æ‚ªo—ˆ‚Ü‚·B
+Elasticsearch ï¿½ÌƒAï¿½Nï¿½eï¿½Bï¿½uï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ï¿½`ï¿½ï¿½ï¿½é‚½ï¿½ß‚É‚ÍAï¿½ï¿½ï¿½È‚ï¿½ï¿½Ìƒï¿½ï¿½Rï¿½[ï¿½hï¿½Nï¿½ï¿½ï¿½Xï¿½ï¿½ [[yii\elasticsearch\ActiveRecord]] ï¿½ï¿½ï¿½ï¿½gï¿½ï¿½ï¿½ï¿½ï¿½ÄAï¿½Å’ï¿½ï¿½ï¿½Aï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½Ì‘ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½`ï¿½ï¿½ï¿½é‚½ï¿½ß‚ï¿½ [[yii\elasticsearch\ActiveRecord::attributes()|attributes()]] ï¿½ï¿½ï¿½\ï¿½bï¿½hï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Kï¿½vï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
+Elasticsearch ï¿½Å‚Íƒvï¿½ï¿½ï¿½Cï¿½}ï¿½ï¿½ï¿½Lï¿½[ï¿½Ìˆï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Êï¿½ÆˆÙ‚È‚ï¿½Ü‚ï¿½ï¿½B
+ï¿½Æ‚ï¿½ï¿½ï¿½ï¿½Ì‚ÍAï¿½vï¿½ï¿½ï¿½Cï¿½}ï¿½ï¿½ï¿½Lï¿½[ (elasticsearch ï¿½Ì—pï¿½ï¿½Å‚ï¿½ `_id` ï¿½tï¿½Bï¿½[ï¿½ï¿½ï¿½h) ï¿½ï¿½ï¿½Aï¿½fï¿½tï¿½Hï¿½ï¿½ï¿½gï¿½Å‚Í‘ï¿½ï¿½ï¿½ï¿½Ì‚ï¿½ï¿½ï¿½ï¿½É“ï¿½ï¿½È‚ï¿½ï¿½ï¿½ï¿½ï¿½Å‚ï¿½ï¿½B
+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½A`_id` ï¿½tï¿½Bï¿½[ï¿½ï¿½ï¿½hï¿½ğ‘®ï¿½ï¿½ÉŠÜ‚ß‚é‚½ï¿½ß‚ï¿½ [ï¿½pï¿½Xï¿½}ï¿½bï¿½sï¿½ï¿½ï¿½O](http://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html) ï¿½ï¿½ï¿½`ï¿½ï¿½ï¿½é‚±ï¿½Æ‚Íoï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
+ï¿½pï¿½Xï¿½}ï¿½bï¿½sï¿½ï¿½ï¿½Oï¿½Ì’ï¿½`ï¿½Ìdï¿½ï¿½É‚Â‚ï¿½ï¿½Ä‚ÍA[elasticsearch ï¿½Ìƒhï¿½Lï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½g](http://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html) ï¿½ï¿½ï¿½Qï¿½Æ‚ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½B
+document ï¿½Ü‚ï¿½ï¿½ï¿½ record ï¿½ï¿½ `_id` ï¿½tï¿½Bï¿½[ï¿½ï¿½ï¿½hï¿½ÍA[[yii\elasticsearch\ActiveRecord::getPrimaryKey()|getPrimaryKey()]] ï¿½ï¿½ï¿½ï¿½ï¿½ [[yii\elasticsearch\ActiveRecord::setPrimaryKey()|setPrimaryKey()]] ï¿½ï¿½ï¿½gï¿½ï¿½ï¿½ÄƒAï¿½Nï¿½Zï¿½Xï¿½ï¿½ï¿½é‚±ï¿½Æ‚ï¿½ï¿½oï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
+ï¿½pï¿½Xï¿½}ï¿½bï¿½sï¿½ï¿½ï¿½Oï¿½ï¿½ï¿½ï¿½`ï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ê‡ï¿½ÍA[[yii\elasticsearch\ActiveRecord::primaryKey()|primaryKey()]] ï¿½ï¿½ï¿½\ï¿½bï¿½hï¿½ï¿½ï¿½gï¿½ï¿½ï¿½Ä‘ï¿½ï¿½ï¿½ï¿½Ì–ï¿½ï¿½Oï¿½ï¿½ï¿½`ï¿½ï¿½ï¿½é‚±ï¿½Æ‚ï¿½ï¿½oï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
 
-ˆÈ‰º‚Í `Customer` ‚ÆŒÄ‚Î‚ê‚éƒ‚ƒfƒ‹‚Ì—á‚Å‚·B
+ï¿½È‰ï¿½ï¿½ï¿½ `Customer` ï¿½ÆŒÄ‚Î‚ï¿½éƒ‚ï¿½fï¿½ï¿½ï¿½Ì—ï¿½Å‚ï¿½ï¿½B
 
 ```php
 class Customer extends \yii\elasticsearch\ActiveRecord
 {
     /**
-     * @return array ‚±‚ÌƒŒƒR[ƒh‚Ì‘®«‚ÌƒŠƒXƒg
+     * @return array ï¿½ï¿½ï¿½Ìƒï¿½ï¿½Rï¿½[ï¿½hï¿½Ì‘ï¿½ï¿½ï¿½ï¿½Ìƒï¿½ï¿½Xï¿½g
      */
     public function attributes()
     {
-        // '_id' ‚É‘Î‚·‚éƒpƒXƒ}ƒbƒsƒ“ƒOis setup to field 'id'
+        // '_id' ï¿½É‘Î‚ï¿½ï¿½ï¿½pï¿½Xï¿½}ï¿½bï¿½sï¿½ï¿½ï¿½Ois setup to field 'id'
         return ['id', 'name', 'address', 'registration_date'];
     }
 
     /**
-     * @return ActiveQuery Order ƒŒƒR[ƒh ‚Ö‚ÌƒŠƒŒ[ƒVƒ‡ƒ“‚ğ’è‹`
-     * (Order ‚Í‘¼‚Ìƒf[ƒ^ƒx[ƒXA—á‚¦‚ÎAredis ‚â’Êí‚Ì SQLDB ‚É‚ ‚Á‚Ä‚à—Ç‚¢)
+     * @return ActiveQuery Order ï¿½ï¿½ï¿½Rï¿½[ï¿½h ï¿½Ö‚Ìƒï¿½ï¿½ï¿½ï¿½[ï¿½Vï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½`
+     * (Order ï¿½Í‘ï¿½ï¿½Ìƒfï¿½[ï¿½^ï¿½xï¿½[ï¿½Xï¿½Aï¿½á‚¦ï¿½ÎAredis ï¿½ï¿½Êï¿½ï¿½ SQLDB ï¿½É‚ï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½Ç‚ï¿½)
      */
     public function getOrders()
     {
@@ -35,7 +35,7 @@ class Customer extends \yii\elasticsearch\ActiveRecord
     }
 
     /**
-     * `$query` ‚ğC³‚µ‚ÄƒAƒNƒeƒBƒu (status = 1) ‚ÈŒÚ‹q‚¾‚¯‚ğ•Ô‚·ƒXƒR[ƒv‚ğ’è‹`
+     * `$query` ï¿½ï¿½ï¿½Cï¿½ï¿½ï¿½ï¿½ï¿½ÄƒAï¿½Nï¿½eï¿½Bï¿½u (status = 1) ï¿½ÈŒÚ‹qï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ô‚ï¿½ï¿½Xï¿½Rï¿½[ï¿½vï¿½ï¿½ï¿½`
      */
     public static function active($query)
     {
@@ -44,61 +44,61 @@ class Customer extends \yii\elasticsearch\ActiveRecord
 }
 ```
 
-[[yii\elasticsearch\ActiveRecord::index()|index()]] ‚Æ [[yii\elasticsearch\ActiveRecord::type()|type()]] ‚ğƒI[ƒo[ƒ‰ƒCƒh‚µ‚ÄA‚±‚ÌƒŒƒR[ƒh‚ª•\‚·ƒCƒ“ƒfƒbƒNƒX‚Æƒ^ƒCƒv‚ğ’è‹`‚·‚é‚±‚Æ‚ªo—ˆ‚Ü‚·B
+[[yii\elasticsearch\ActiveRecord::index()|index()]] ï¿½ï¿½ [[yii\elasticsearch\ActiveRecord::type()|type()]] ï¿½ï¿½ï¿½Iï¿½[ï¿½oï¿½[ï¿½ï¿½ï¿½Cï¿½hï¿½ï¿½ï¿½ÄAï¿½ï¿½ï¿½Ìƒï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ï¿½\ï¿½ï¿½ï¿½Cï¿½ï¿½ï¿½fï¿½bï¿½Nï¿½Xï¿½Æƒ^ï¿½Cï¿½vï¿½ï¿½ï¿½`ï¿½ï¿½ï¿½é‚±ï¿½Æ‚ï¿½ï¿½oï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
 
-elasticsearch ‚ÌƒAƒNƒeƒBƒuƒŒƒR[ƒh‚Ìˆê”Ê“I‚Èg—p•û–@‚ÍA[ƒKƒCƒh](https://github.com/yiisoft/yii2/blob/master/docs/guide/active-record.md) ‚Åà–¾‚³‚ê‚½ƒf[ƒ^ƒx[ƒX‚ÌƒAƒNƒeƒBƒuƒŒƒR[ƒh‚Ìê‡‚Æ”ñí‚É‚æ‚­—‚Ä‚¢‚Ü‚·B
-ˆÈ‰º‚Ì§ŒÀ‚ÆŠg’£ (*!*) ‚ª‚ ‚é‚±‚Æ‚ğœ‚¯‚ÎA“¯‚¶ƒCƒ“ƒ^[ƒtƒFƒCƒX‚Æ‹@”\‚ğƒTƒ|[ƒg‚µ‚Ä‚¢‚Ü‚·B
+elasticsearch ï¿½ÌƒAï¿½Nï¿½eï¿½Bï¿½uï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½Ìˆï¿½Ê“Iï¿½Ègï¿½pï¿½ï¿½@ï¿½ÍA[ï¿½Kï¿½Cï¿½h](https://github.com/yiisoft/yii2/blob/master/docs/guide/active-record.md) ï¿½Åï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ê‚½ï¿½fï¿½[ï¿½^ï¿½xï¿½[ï¿½Xï¿½ÌƒAï¿½Nï¿½eï¿½Bï¿½uï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½Ìê‡ï¿½Æ”ï¿½ï¿½É‚æ‚­ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½Ü‚ï¿½ï¿½B
+ï¿½È‰ï¿½ï¿½Ìï¿½ï¿½ï¿½ï¿½ÆŠgï¿½ï¿½ (*!*) ï¿½ï¿½ï¿½ï¿½ï¿½é‚±ï¿½Æ‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ÎAï¿½ï¿½ï¿½ï¿½ï¿½Cï¿½ï¿½ï¿½^ï¿½[ï¿½tï¿½Fï¿½Cï¿½Xï¿½Æ‹@ï¿½\ï¿½ï¿½ï¿½Tï¿½|ï¿½[ï¿½gï¿½ï¿½ï¿½Ä‚ï¿½ï¿½Ü‚ï¿½ï¿½B
 
-- elasticsearch ‚Í SQL ‚ğƒTƒ|[ƒg‚µ‚Ä‚¢‚È‚¢‚½‚ßAƒNƒGƒŠ‚Ì API ‚Í `join()`A`groupBy()`A`having()` ‚¨‚æ‚Ñ `union()` ‚ğƒTƒ|[ƒg‚µ‚Ü‚¹‚ñB
-  •À‚×‘Ö‚¦AƒŠƒ~ƒbƒgAƒIƒtƒZƒbƒgAğŒ•t‚« WHERE ‚ÍA‚·‚×‚ÄƒTƒ|[ƒg‚³‚ê‚Ä‚¢‚Ü‚·B
-- [[yii\elasticsearch\ActiveQuery::from()|from()]] ‚Íƒe[ƒuƒ‹‚ğ‘I‘ğ‚µ‚Ü‚¹‚ñB
-  ‚»‚¤‚Å‚Í‚È‚­AƒNƒGƒŠ‘ÎÛ‚Ì [ƒCƒ“ƒfƒbƒNƒX](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/glossary.html#glossary-index) ‚Æ [ƒ^ƒCƒv](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/glossary.html#glossary-type) ‚ğ‘I‘ğ‚µ‚Ü‚·B
-- `select()` ‚Í [[yii\elasticsearch\ActiveQuery::fields()|fields()]] ‚É’u‚«Š·‚¦‚ç‚ê‚Ä‚¢‚Ü‚·B
-  Šî–{“I‚É‚Í“¯‚¶‚±‚Æ‚ğ‚·‚é‚à‚Ì‚Å‚·‚ªA`fields` ‚Ì•û‚ª elasticsearch ‚Ì—pŒê‚Æ‚µ‚Ä‘Š‰‚µ‚¢‚Å‚µ‚å‚¤B
-  ƒhƒLƒ…ƒƒ“ƒg‚©‚çæ“¾‚·‚éƒtƒB[ƒ‹ƒh‚ğ’è‹`‚µ‚Ü‚·B
-- Elasticsearch ‚É‚Íƒe[ƒuƒ‹‚ª‚ ‚è‚Ü‚¹‚ñ‚Ì‚ÅAƒe[ƒuƒ‹‚ğ’Ê‚¶‚Ä‚Ì [[yii\elasticsearch\ActiveQuery::via()|via]] ƒŠƒŒ[ƒVƒ‡ƒ“‚Í’è‹`‚·‚é‚±‚Æ‚ªo—ˆ‚Ü‚¹‚ñB
-- Elasticsearch ‚Íƒf[ƒ^ƒXƒgƒŒ[ƒW‚Å‚ ‚é‚Æ“¯‚ÉŒŸõƒGƒ“ƒWƒ“‚Å‚à‚ ‚è‚Ü‚·‚Ì‚ÅA“–‘R‚È‚ª‚çAƒŒƒR[ƒh‚ÌŒŸõ‚É‘Î‚·‚éƒTƒ|[ƒg‚ª’Ç‰Á‚³‚ê‚Ä‚¢‚Ü‚·B
-  Elasticsearch ‚ÌƒNƒGƒŠ‚ğ\¬‚·‚é‚½‚ß‚Ì [[yii\elasticsearch\ActiveQuery::query()|query()]]A[[yii\elasticsearch\ActiveQuery::filter()|filter()]] ‚»‚µ‚Ä [[yii\elasticsearch\ActiveQuery::addFacet()|addFacet()]] ‚Æ‚¢‚¤ƒƒ\ƒbƒh‚ª‚ ‚è‚Ü‚·B
-  ‚±‚ê‚ç‚ª‚Ç‚Ì‚æ‚¤‚É“­‚­‚©‚É‚Â‚¢‚ÄA‰º‚Ìg—p—á‚ğŒ©‚Ä‚­‚¾‚³‚¢B
-  ‚Ü‚½A`query` ‚Æ `filter` ‚Ì•”•ª‚ğ\¬‚·‚é•û–@‚É‚Â‚¢‚Ä‚ÍA[Query DSL](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html) ‚ğQÆ‚µ‚Ä‚­‚¾‚³‚¢B
-- Elasticsearch ‚ÌƒAƒNƒeƒBƒuƒŒƒR[ƒh‚©‚ç’Êí‚ÌƒAƒNƒeƒBƒuƒŒƒR[ƒhƒNƒ‰ƒX‚Ö‚ÌƒŠƒŒ[ƒVƒ‡ƒ“‚ğ’è‹`‚·‚é‚±‚Æ‚à‰Â”\‚Å‚·B‚Ü‚½A‚»‚Ì‹t‚à‰Â”\‚Å‚·B
+- elasticsearch ï¿½ï¿½ SQL ï¿½ï¿½ï¿½Tï¿½|ï¿½[ï¿½gï¿½ï¿½ï¿½Ä‚ï¿½ï¿½È‚ï¿½ï¿½ï¿½ï¿½ßAï¿½Nï¿½Gï¿½ï¿½ï¿½ï¿½ API ï¿½ï¿½ `join()`ï¿½A`groupBy()`ï¿½A`having()` ï¿½ï¿½ï¿½ï¿½ï¿½ `union()` ï¿½ï¿½ï¿½Tï¿½|ï¿½[ï¿½gï¿½ï¿½ï¿½Ü‚ï¿½ï¿½ï¿½B
+  ï¿½ï¿½ï¿½×‘Ö‚ï¿½ï¿½Aï¿½ï¿½ï¿½~ï¿½bï¿½gï¿½Aï¿½Iï¿½tï¿½Zï¿½bï¿½gï¿½Aï¿½ï¿½ï¿½ï¿½ï¿½tï¿½ï¿½ WHERE ï¿½ÍAï¿½ï¿½ï¿½×‚ÄƒTï¿½|ï¿½[ï¿½gï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½Ü‚ï¿½ï¿½B
+- [[yii\elasticsearch\ActiveQuery::from()|from()]] ï¿½Íƒeï¿½[ï¿½uï¿½ï¿½ï¿½ï¿½Iï¿½ï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½ï¿½B
+  ï¿½ï¿½ï¿½ï¿½ï¿½Å‚Í‚È‚ï¿½ï¿½Aï¿½Nï¿½Gï¿½ï¿½ï¿½ÎÛ‚ï¿½ [ï¿½Cï¿½ï¿½ï¿½fï¿½bï¿½Nï¿½X](http://www.elastic.co/guide/en/elasticsearch/reference/current/glossary.html#glossary-index) ï¿½ï¿½ [ï¿½^ï¿½Cï¿½v](http://www.elastic.co/guide/en/elasticsearch/reference/current/glossary.html#glossary-type) ï¿½ï¿½Iï¿½ï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
+- `select()` ï¿½ï¿½ [[yii\elasticsearch\ActiveQuery::fields()|fields()]] ï¿½É’uï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½Ü‚ï¿½ï¿½B
+  ï¿½ï¿½{ï¿½Iï¿½É‚Í“ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Æ‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ì‚Å‚ï¿½ï¿½ï¿½ï¿½A`fields` ï¿½Ì•ï¿½ elasticsearch ï¿½Ì—pï¿½ï¿½Æ‚ï¿½ï¿½Ä‘ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Å‚ï¿½ï¿½å‚¤ï¿½B
+  ï¿½hï¿½Lï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½gï¿½ï¿½ï¿½ï¿½æ“¾ï¿½ï¿½ï¿½ï¿½tï¿½Bï¿½[ï¿½ï¿½ï¿½hï¿½ï¿½ï¿½`ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
+- Elasticsearch ï¿½É‚Íƒeï¿½[ï¿½uï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½ï¿½Ì‚ÅAï¿½eï¿½[ï¿½uï¿½ï¿½ï¿½ï¿½Ê‚ï¿½ï¿½Ä‚ï¿½ [[yii\elasticsearch\ActiveQuery::via()|via]] ï¿½ï¿½ï¿½ï¿½ï¿½[ï¿½Vï¿½ï¿½ï¿½ï¿½ï¿½Í’ï¿½`ï¿½ï¿½ï¿½é‚±ï¿½Æ‚ï¿½ï¿½oï¿½ï¿½ï¿½Ü‚ï¿½ï¿½ï¿½B
+- Elasticsearch ï¿½Íƒfï¿½[ï¿½^ï¿½Xï¿½gï¿½ï¿½ï¿½[ï¿½Wï¿½Å‚ï¿½ï¿½ï¿½Æ“ï¿½ï¿½ï¿½ï¿½ÉŒï¿½ï¿½ï¿½ï¿½Gï¿½ï¿½ï¿½Wï¿½ï¿½ï¿½Å‚ï¿½ï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½Ì‚ÅAï¿½ï¿½ï¿½Rï¿½È‚ï¿½ï¿½ï¿½Aï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½ÌŒï¿½ï¿½ï¿½ï¿½É‘Î‚ï¿½ï¿½ï¿½Tï¿½|ï¿½[ï¿½gï¿½ï¿½ï¿½Ç‰ï¿½ï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½Ü‚ï¿½ï¿½B
+  Elasticsearch ï¿½ÌƒNï¿½Gï¿½ï¿½ï¿½ï¿½ï¿½\ï¿½ï¿½ï¿½ï¿½ï¿½é‚½ï¿½ß‚ï¿½ [[yii\elasticsearch\ActiveQuery::query()|query()]]ï¿½A[[yii\elasticsearch\ActiveQuery::filter()|filter()]] ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ [[yii\elasticsearch\ActiveQuery::addFacet()|addFacet()]] ï¿½Æ‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½\ï¿½bï¿½hï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
+  ï¿½ï¿½ï¿½ï¿½ç‚ªï¿½Ç‚Ì‚æ‚¤ï¿½É“ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½É‚Â‚ï¿½ï¿½ÄAï¿½ï¿½ï¿½Ìgï¿½pï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½B
+  ï¿½Ü‚ï¿½ï¿½A`query` ï¿½ï¿½ `filter` ï¿½Ì•ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½\ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½@ï¿½É‚Â‚ï¿½ï¿½Ä‚ÍA[Query DSL](http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html) ï¿½ï¿½ï¿½Qï¿½Æ‚ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½B
+- Elasticsearch ï¿½ÌƒAï¿½Nï¿½eï¿½Bï¿½uï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ï¿½ï¿½Êï¿½ÌƒAï¿½Nï¿½eï¿½Bï¿½uï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½Nï¿½ï¿½ï¿½Xï¿½Ö‚Ìƒï¿½ï¿½ï¿½ï¿½[ï¿½Vï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½`ï¿½ï¿½ï¿½é‚±ï¿½Æ‚ï¿½ï¿½Â”\ï¿½Å‚ï¿½ï¿½Bï¿½Ü‚ï¿½ï¿½Aï¿½ï¿½ï¿½Ì‹tï¿½ï¿½ï¿½Â”\ï¿½Å‚ï¿½ï¿½B
 
-> Note|**’ˆÓ**: ƒfƒtƒHƒ‹ƒg‚Å‚ÍAelasticsearch ‚ÍA‚Ç‚ñ‚ÈƒNƒGƒŠ‚Å‚àA•Ô‚³‚ê‚éƒŒƒR[ƒh‚Ì”‚ğ 10 ‚ÉŒÀ’è‚µ‚Ä‚¢‚Ü‚·B
-> ‚à‚Á‚Æ‘½‚­‚ÌƒŒƒR[ƒh‚ğæ“¾‚·‚é‚±‚Æ‚ğŠú‘Ò‚·‚éê‡‚ÍAƒŠƒŒ[ƒVƒ‡ƒ“‚Ì’è‹`‚ÅãŒÀ‚ğ–¾¦“I‚Éw’è‚µ‚È‚¯‚ê‚Î‚È‚è‚Ü‚¹‚ñB
-> ‚±‚Ì‚±‚Æ‚ÍAvia() ‚ğg‚¤ƒŠƒŒ[ƒVƒ‡ƒ“‚É‚Æ‚Á‚Ä‚àd—v‚Å‚·B
-> ‚È‚º‚È‚çAvia ‚ÌƒŒƒR[ƒh‚ª 10 ‚Ü‚Å‚É§ŒÀ‚³‚ê‚Ä‚¢‚éê‡‚ÍAƒŠƒŒ[ƒVƒ‡ƒ“‚ÌƒŒƒR[ƒh‚à 10 ‚ğ’´‚¦‚é‚±‚Æ‚Ío—ˆ‚È‚¢‚©‚ç‚Å‚·B
+> Note|**ï¿½ï¿½ï¿½ï¿½**: ï¿½fï¿½tï¿½Hï¿½ï¿½ï¿½gï¿½Å‚ÍAelasticsearch ï¿½ÍAï¿½Ç‚ï¿½ÈƒNï¿½Gï¿½ï¿½ï¿½Å‚ï¿½ï¿½Aï¿½Ô‚ï¿½ï¿½ï¿½éƒŒï¿½Rï¿½[ï¿½hï¿½Ìï¿½ï¿½ï¿½ 10 ï¿½ÉŒï¿½ï¿½è‚µï¿½Ä‚ï¿½ï¿½Ü‚ï¿½ï¿½B
+> ï¿½ï¿½ï¿½ï¿½ï¿½Æ‘ï¿½ï¿½ï¿½ï¿½Ìƒï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ï¿½æ“¾ï¿½ï¿½ï¿½é‚±ï¿½Æ‚ï¿½ï¿½ï¿½Ò‚ï¿½ï¿½ï¿½ê‡ï¿½ÍAï¿½ï¿½ï¿½ï¿½ï¿½[ï¿½Vï¿½ï¿½ï¿½ï¿½ï¿½Ì’ï¿½`ï¿½Åï¿½ï¿½ï¿½ğ–¾ï¿½ï¿½Iï¿½Éwï¿½è‚µï¿½È‚ï¿½ï¿½ï¿½Î‚È‚ï¿½Ü‚ï¿½ï¿½ï¿½B
+> ï¿½ï¿½ï¿½Ì‚ï¿½ï¿½Æ‚ÍAvia() ï¿½ï¿½ï¿½gï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½[ï¿½Vï¿½ï¿½ï¿½ï¿½ï¿½É‚Æ‚ï¿½ï¿½Ä‚ï¿½ï¿½dï¿½vï¿½Å‚ï¿½ï¿½B
+> ï¿½È‚ï¿½ï¿½È‚ï¿½Avia ï¿½Ìƒï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ 10 ï¿½Ü‚Å‚Éï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ê‡ï¿½ÍAï¿½ï¿½ï¿½ï¿½ï¿½[ï¿½Vï¿½ï¿½ï¿½ï¿½ï¿½Ìƒï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ 10 ï¿½ğ’´‚ï¿½ï¿½é‚±ï¿½Æ‚Íoï¿½ï¿½ï¿½È‚ï¿½ï¿½ï¿½ï¿½ï¿½Å‚ï¿½ï¿½B
 
 
-g—p—á:
+ï¿½gï¿½pï¿½ï¿½:
 
 ```php
 $customer = new Customer();
-$customer->primaryKey = 1; // ‚±‚Ìê‡‚ÍA$customer->id = 1 ‚Æ“™‰¿
+$customer->primaryKey = 1; // ï¿½ï¿½ï¿½Ìê‡ï¿½ÍA$customer->id = 1 ï¿½Æ“ï¿½ï¿½ï¿½
 $customer->attributes = ['name' => 'test'];
 $customer->save();
 
-$customer = Customer::get(1); // PK ‚É‚æ‚Á‚ÄƒŒƒR[ƒh‚ğæ“¾
-$customers = Customer::mget([1,2,3]); // PK ‚É‚æ‚Á‚Ä•¡”‚ÌƒŒƒR[ƒh‚ğæ“¾
-$customer = Customer::find()->where(['name' => 'test'])->one(); // ƒNƒGƒŠ‚É‚æ‚éæ“¾BƒŒƒR[ƒh‚ğ³‚µ‚­æ“¾‚·‚é‚½‚ß‚É‚Í‚±‚ÌƒtƒB[ƒ‹ƒh‚Éƒ}ƒbƒsƒ“ƒO‚ğ\¬‚·‚é•K—v‚ª‚ ‚é‚±‚Æ‚É’ˆÓB
-$customers = Customer::find()->active()->all(); // ƒNƒGƒŠ‚É‚æ‚Á‚Ä‘S‚Ä‚ğæ“¾ (`active` ƒXƒR[ƒv‚ğg‚Á‚Ä)
+$customer = Customer::get(1); // PK ï¿½É‚ï¿½ï¿½ï¿½Äƒï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ï¿½æ“¾
+$customers = Customer::mget([1,2,3]); // PK ï¿½É‚ï¿½ï¿½ï¿½Ä•ï¿½ï¿½ï¿½ï¿½Ìƒï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ï¿½æ“¾
+$customer = Customer::find()->where(['name' => 'test'])->one(); // ï¿½Nï¿½Gï¿½ï¿½ï¿½É‚ï¿½ï¿½æ“¾ï¿½Bï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½ğ³‚ï¿½ï¿½ï¿½ï¿½æ“¾ï¿½ï¿½ï¿½é‚½ï¿½ß‚É‚Í‚ï¿½ï¿½Ìƒtï¿½Bï¿½[ï¿½ï¿½ï¿½hï¿½Éƒ}ï¿½bï¿½sï¿½ï¿½ï¿½Oï¿½ï¿½ï¿½\ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Kï¿½vï¿½ï¿½ï¿½ï¿½ï¿½é‚±ï¿½Æ‚É’ï¿½ï¿½ÓB
+$customers = Customer::find()->active()->all(); // ï¿½Nï¿½Gï¿½ï¿½ï¿½É‚ï¿½ï¿½ï¿½Ä‘Sï¿½Ä‚ï¿½ï¿½æ“¾ (`active` ï¿½Xï¿½Rï¿½[ï¿½vï¿½ï¿½ï¿½gï¿½ï¿½ï¿½ï¿½)
 
-// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
+// http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
 $result = Article::find()->query(["match" => ["title" => "yii"]])->all(); // articles whose title contains "yii"
 
-// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-flt-query.html
+// http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-flt-query.html
 $query = Article::find()->query([
     "fuzzy_like_this" => [
         "fields" => ["title", "description"],
-        "like_text" => "‚±‚ÌƒNƒGƒŠ‚ÍA‚±‚ÌƒeƒLƒXƒg‚É—‚½‹L–‚ğ•Ô‚µ‚Ü‚· :-)",
+        "like_text" => "ï¿½ï¿½ï¿½ÌƒNï¿½Gï¿½ï¿½ï¿½ÍAï¿½ï¿½ï¿½Ìƒeï¿½Lï¿½Xï¿½gï¿½Éï¿½ï¿½ï¿½ï¿½Lï¿½ï¿½ï¿½ï¿½Ô‚ï¿½ï¿½Ü‚ï¿½ :-)",
         "max_query_terms" => 12
     ]
 ]);
 
-$query->all(); // ‘S‚Ä‚ÌƒhƒLƒ…ƒƒ“ƒg‚ğæ“¾
-// ŒŸõ‚É facets ‚ğ’Ç‰Á‚Å‚«‚é
+$query->all(); // ï¿½Sï¿½Ä‚Ìƒhï¿½Lï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½gï¿½ï¿½ï¿½æ“¾
+// ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ facets ï¿½ï¿½Ç‰ï¿½ï¿½Å‚ï¿½ï¿½ï¿½
 $query->addStatisticalFacet('click_stats', ['field' => 'visit_count']);
-$query->search(); // ‘S‚Ä‚ÌƒŒƒR[ƒhA‚¨‚æ‚ÑAvisit_count ƒtƒB[ƒ‹ƒh‚ÉŠÖ‚·‚é“Œv (—á‚¦‚ÎA•½‹ÏA‡ŒvAÅ¬AÅ‘å‚È‚Ç) ‚ğæ“¾
+$query->search(); // ï¿½Sï¿½Ä‚Ìƒï¿½ï¿½Rï¿½[ï¿½hï¿½Aï¿½ï¿½ï¿½ï¿½ÑAvisit_count ï¿½tï¿½Bï¿½[ï¿½ï¿½ï¿½hï¿½ÉŠÖ‚ï¿½ï¿½é“ï¿½v (ï¿½á‚¦ï¿½ÎAï¿½ï¿½ï¿½ÏAï¿½ï¿½ï¿½vï¿½Aï¿½Åï¿½ï¿½Aï¿½Å‘ï¿½È‚ï¿½) ï¿½ï¿½ï¿½æ“¾
 ```
 
-‚»‚µ‚ÄA‚Ü‚¾A‚¢‚ë‚¢‚ë‚Æ‘òR‚ ‚è‚Ü‚·B
-"it's endless what you can build"[?](http://www.elasticsearch.org/)
+ï¿½ï¿½ï¿½ï¿½ï¿½ÄAï¿½Ü‚ï¿½ï¿½Aï¿½ï¿½ï¿½ë‚¢ï¿½ï¿½Æ‘ï¿½Rï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
+"it's endless what you can build"[?](https://www.elastic.co/)

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -1,7 +1,7 @@
 Elasticsearch Extension for Yii 2
 =================================
 
-This extension provides the [elasticsearch](http://www.elasticsearch.org/) integration for the Yii2 framework.
+This extension provides the [elasticsearch](https://www.elastic.co/) integration for the Yii2 framework.
 It includes basic querying/search support and also implements the `ActiveRecord` pattern that allows you to store active
 records in elasticsearch.
 

--- a/docs/guide/usage-ar.md
+++ b/docs/guide/usage-ar.md
@@ -107,4 +107,4 @@ $query->addStatisticalFacet('click_stats', ['field' => 'visit_count']);
 $query->search(); // gives you all the records + stats about the visit_count field. e.g. mean, sum, min, max etc...
 ```
 
-And there is so much more in it. "it�s endless what you can build"[?](https://www.elastic.co/)
+And there is so much more in it. "it’s endless what you can build"[?](https://www.elastic.co/)

--- a/docs/guide/usage-ar.md
+++ b/docs/guide/usage-ar.md
@@ -6,9 +6,9 @@ For general information on how to use yii's ActiveRecord please refer to the [gu
 For defining an elasticsearch ActiveRecord class your record class needs to extend from [[yii\elasticsearch\ActiveRecord]] and
 implement at least the [[yii\elasticsearch\ActiveRecord::attributes()|attributes()]] method to define the attributes of the record.
 The handling of primary keys is different in elasticsearch as the primary key (the `_id` field in elasticsearch terms)
-is not part of the attributes by default. However it is possible to define a [path mapping](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-id-field.html)
+is not part of the attributes by default. However it is possible to define a [path mapping](http://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html)
 for the `_id` field to be part of the attributes.
-See [elasticsearch docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-id-field.html) on how to define it.
+See [elasticsearch docs](http://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html) on how to define it.
 The `_id` field of a document/record can be accessed using [[yii\elasticsearch\ActiveRecord::getPrimaryKey()|getPrimaryKey()]] and
 [[yii\elasticsearch\ActiveRecord::setPrimaryKey()|setPrimaryKey()]].
 When path mapping is defined, the attribute name can be defined using the [[yii\elasticsearch\ActiveRecord::primaryKey()|primaryKey()]] method.
@@ -55,8 +55,8 @@ It supports the same interface and features except the following limitations and
 - As elasticsearch does not support SQL, the query API does not support `join()`, `groupBy()`, `having()` and `union()`.
   Sorting, limit, offset and conditional where are all supported.
 - [[yii\elasticsearch\ActiveQuery::from()|from()]] does not select the tables, but the
-  [index](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/glossary.html#glossary-index)
-  and [type](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/glossary.html#glossary-type) to query against.
+  [index](http://www.elastic.co/guide/en/elasticsearch/reference/current/glossary.html#glossary-index)
+  and [type](http://www.elastic.co/guide/en/elasticsearch/reference/current/glossary.html#glossary-type) to query against.
 - `select()` has been replaced with [[yii\elasticsearch\ActiveQuery::fields()|fields()]] which basically does the same but
   `fields` is more elasticsearch terminology.
   It defines the fields to retrieve from a document.
@@ -66,7 +66,7 @@ It supports the same interface and features except the following limitations and
   [[yii\elasticsearch\ActiveQuery::query()|query()]],
   [[yii\elasticsearch\ActiveQuery::filter()|filter()]] and
   [[yii\elasticsearch\ActiveQuery::addFacet()|addFacet()]] methods that allows to compose an elasticsearch query.
-  See the usage example below on how they work and check out the [Query DSL](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html)
+  See the usage example below on how they work and check out the [Query DSL](http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html)
   on how to compose `query` and `filter` parts.
 - It is also possible to define relations from elasticsearch ActiveRecords to normal ActiveRecord classes and vice versa.
 
@@ -89,10 +89,10 @@ $customers = Customer::mget([1,2,3]); // get multiple records by pk
 $customer = Customer::find()->where(['name' => 'test'])->one(); // find by query, note that you need to configure mapping for this field in order to find records properly
 $customers = Customer::find()->active()->all(); // find all by query (using the `active` scope)
 
-// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
+// http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
 $result = Article::find()->query(["match" => ["title" => "yii"]])->all(); // articles whose title contains "yii"
 
-// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-flt-query.html
+// http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-flt-query.html
 $query = Article::find()->query([
     "fuzzy_like_this" => [
         "fields" => ["title", "description"],
@@ -107,4 +107,4 @@ $query->addStatisticalFacet('click_stats', ['field' => 'visit_count']);
 $query->search(); // gives you all the records + stats about the visit_count field. e.g. mean, sum, min, max etc...
 ```
 
-And there is so much more in it. "it’s endless what you can build"[?](http://www.elasticsearch.org/)
+And there is so much more in it. "itï¿½s endless what you can build"[?](https://www.elastic.co/)


### PR DESCRIPTION
Blog post - https://www.elastic.co/blog/elastic-you-know-for-more-than-search
For the guide sections HTTPS protocol is disabled, that's why only homepage refers to https page.