### PR TITLE
Elasticsearch auth implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 elasticsearch extension Change Log
 - Bug #8: Fixed issue with running out of sockets when running a large number of requests by reusing curl handles (cebe)
 - Enh #28: AWS Elasticsearch service compatibility (andrey-bahrachev)
 - Enh #33: Implemented `Command::updateSettings()` and `Command::updateAnalyzers()` (githubjeka)
+- Enh: Implemented HTTP auth (silverfire)
 
 2.0.3 March 01, 2015
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Yii Framework 2 elasticsearch extension Change Log
 - Bug #8: Fixed issue with running out of sockets when running a large number of requests by reusing curl handles (cebe)
 - Enh #28: AWS Elasticsearch service compatibility (andrey-bahrachev)
 - Enh #33: Implemented `Command::updateSettings()` and `Command::updateAnalyzers()` (githubjeka)
-- Enh: Implemented HTTP auth (silverfire)
+- Enh #50: Implemented HTTP auth (silverfire)
 
 2.0.3 March 01, 2015
 --------------------

--- a/Connection.php
+++ b/Connection.php
@@ -399,7 +399,7 @@ class Connection extends Component
             }
 
             $options[CURLOPT_HTTPAUTH] = CURLAUTH_BASIC;
-            $headers['Authorization'] = 'Basic: ' . base64_encode($auth['username'] . ':' . $auth['password']);
+            $options[CURLOPT_USERPWD] = $auth['username'] . ':' . $auth['password'];
         }
 
         if ($this->connectionTimeout !== null) {

--- a/Connection.php
+++ b/Connection.php
@@ -57,11 +57,11 @@ class Connection extends Component
     public $activeNode;
 
     /**
-     * @var array|\Closure Authorization data used to connect to the ElasticSearch node.
-     * Possible array elements:
+     * @var array Authentication data used to connect to the ElasticSearch node.
+     * Array elements:
      *  - `username`: the username for authentication.
      *  - `password`: the password for authentication.
-     * Array MUST contain both `username` and `password`, when is set.
+     * Array either MUST contain both username and password on not contain any authentication credentials.
      * @see http://www.elasticsearch.org/guide/en/elasticsearch/client/php-api/current/_configuration.html#_example_configuring_http_basic_auth
      */
     public $auth = [];


### PR DESCRIPTION
The code is tested and works as expected.
I'm not sure whether it can be covered by unit tests because it requires special ES server configuration. We can not mock it because CURL options are never exposed from the `httpRequest()`