### PR TITLE
Alternative scoll/scan implementation

### DIFF
--- a/ActiveQuery.php
+++ b/ActiveQuery.php
@@ -165,6 +165,12 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         return parent::all($db);
     }
 
+    /**
+     * Converts found rows into model instances
+     * @param array $rows
+     * @return array|ActiveRecord[]
+     * @since 2.0.4
+     */
     private function createModels($rows)
     {
         $models = [];
@@ -210,6 +216,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
 
     /**
      * @inheritdoc
+     * @since 2.0.4
      */
     public function populate($rows)
     {

--- a/ActiveQuery.php
+++ b/ActiveQuery.php
@@ -162,21 +162,69 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      */
     public function all($db = null)
     {
+        return parent::all($db);
+    }
+
+    private function createModels($rows)
+    {
+        $models = [];
         if ($this->asArray) {
-            // TODO implement with
-            return parent::all($db);
+            if ($this->indexBy === null) {
+                return $rows;
+            }
+            foreach ($rows as $row) {
+                if (is_string($this->indexBy)) {
+                    $key = isset($row['fields'][$this->indexBy]) ? reset($row['fields'][$this->indexBy]) : $row['_source'][$this->indexBy];
+                } else {
+                    $key = call_user_func($this->indexBy, $row);
+                }
+                $models[$key] = $row;
+            }
+        } else {
+            /* @var $class ActiveRecord */
+            $class = $this->modelClass;
+            if ($this->indexBy === null) {
+                foreach ($rows as $row) {
+                    $model = $class::instantiate($row);
+                    $modelClass = get_class($model);
+                    $modelClass::populateRecord($model, $row);
+                    $models[] = $model;
+                }
+            } else {
+                foreach ($rows as $row) {
+                    $model = $class::instantiate($row);
+                    $modelClass = get_class($model);
+                    $modelClass::populateRecord($model, $row);
+                    if (is_string($this->indexBy)) {
+                        $key = $model->{$this->indexBy};
+                    } else {
+                        $key = call_user_func($this->indexBy, $model);
+                    }
+                    $models[$key] = $model;
+                }
+            }
         }
 
-        $result = $this->createCommand($db)->search();
-        if (empty($result['hits']['hits'])) {
+        return $models;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function populate($rows)
+    {
+        if (empty($rows)) {
             return [];
         }
-        $models = $this->createModels($result['hits']['hits']);
+
+        $models = $this->createModels($rows);
         if (!empty($this->with)) {
             $this->findWith($this->with, $models);
         }
-        foreach ($models as $model) {
-            $model->afterFind();
+        if (!$this->asArray) {
+            foreach ($models as $model) {
+                $model->afterFind();
+            }
         }
 
         return $models;

--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -565,6 +565,7 @@ class ActiveRecord extends BaseActiveRecord
      * @see updateAll()
      * @see updateAllCounters()
      * @see deleteAll()
+     * @since 2.0.4
      */
     protected static function primaryKeysByCondition($condition)
     {

--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -558,6 +558,31 @@ class ActiveRecord extends BaseActiveRecord
     }
 
     /**
+     * Performs a quick and highly efficient scroll/scan query to get the list of primary keys that
+     * satisfy the given condition.
+     * @param array $condition please refer to [[ActiveQuery::where()]] on how to specify this parameter
+     * @return array primary keys that correspond to given conditions
+     * @see updateAll()
+     * @see updateAllCounters()
+     * @see deleteAll()
+     */
+    protected static function primaryKeysByCondition($condition)
+    {
+        $pkName = static::primaryKey()[0];
+        if (count($condition) == 1 && isset($condition[$pkName])) {
+            $primaryKeys = (array)$condition[$pkName];
+        } else {
+            //fetch only document metadata (no fields), 1000 documents per shard
+            $query = static::find()->where($condition)->asArray()->source(false)->limit(1000);
+            $primaryKeys = [];
+            foreach ($query->each('1m') as $document) {
+                $primaryKeys[] = $document['_id'];
+            }
+        }
+        return $primaryKeys;
+    }
+
+    /**
      * Updates all records whos primary keys are given.
      * For example, to change the status to be 1 for all customers whose status is 2:
      *
@@ -573,12 +598,7 @@ class ActiveRecord extends BaseActiveRecord
      */
     public static function updateAll($attributes, $condition = [])
     {
-        $pkName = static::primaryKey()[0];
-        if (count($condition) == 1 && isset($condition[$pkName])) {
-            $primaryKeys = (array)$condition[$pkName];
-        } else {
-            $primaryKeys = static::find()->where($condition)->column($pkName); // TODO check whether this works with default pk _id
-        }
+        $primaryKeys = static::primaryKeysByCondition($condition);
         if (empty($primaryKeys)) {
             return 0;
         }
@@ -633,12 +653,7 @@ class ActiveRecord extends BaseActiveRecord
      */
     public static function updateAllCounters($counters, $condition = [])
     {
-        $pkName = static::primaryKey()[0];
-        if (count($condition) == 1 && isset($condition[$pkName])) {
-            $primaryKeys = (array)$condition[$pkName];
-        } else {
-            $primaryKeys = static::find()->where($condition)->column($pkName); // TODO check whether this works with default pk _id
-        }
+        $primaryKeys = static::primaryKeysByCondition($condition);
         if (empty($primaryKeys) || empty($counters)) {
             return 0;
         }
@@ -769,12 +784,7 @@ class ActiveRecord extends BaseActiveRecord
      */
     public static function deleteAll($condition = [])
     {
-        $pkName = static::primaryKey()[0];
-        if (count($condition) == 1 && isset($condition[$pkName])) {
-            $primaryKeys = (array)$condition[$pkName];
-        } else {
-            $primaryKeys = static::find()->where($condition)->column($pkName); // TODO check whether this works with default pk _id
-        }
+        $primaryKeys = static::primaryKeysByCondition($condition);
         if (empty($primaryKeys)) {
             return 0;
         }

--- a/BatchQueryResult.php
+++ b/BatchQueryResult.php
@@ -35,7 +35,7 @@ use yii\db\BatchQueryResult as BaseBatchQueryResult;
  * ```
  *
  * @author Konstantin Sirotkin <beowulfenator@gmail.com>
- * @since 2.0
+ * @since 2.0.4
  */
 class BatchQueryResult extends BaseBatchQueryResult implements \Iterator
 {

--- a/BatchQueryResult.php
+++ b/BatchQueryResult.php
@@ -41,7 +41,7 @@ class BatchQueryResult extends Object implements \Iterator
 {
     /**
      * @var Connection the DB connection to be used when performing batch query.
-     * If null, the "db" application component will be used.
+     * If null, the `elasticsearch` application component will be used.
      */
     public $db;
     /**

--- a/BatchQueryResult.php
+++ b/BatchQueryResult.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\elasticsearch;
+
+use yii\db\BatchQueryResult as BaseBatchQueryResult;
+
+/**
+ * BatchQueryResult represents a batch query from which you can retrieve data in batches.
+ *
+ * You usually do not instantiate BatchQueryResult directly. Instead, you obtain it by
+ * calling [[Query::batch()]] or [[Query::each()]]. Because BatchQueryResult implements the [[\Iterator]] interface,
+ * you can iterate it to obtain a batch of data in each iteration.
+ *
+ * Batch size is determined by the [[Query::$limit]] setting. [[Query::$offset]] setting is ignored.
+ * New batches will be obtained until the server runs out of results.
+ *
+ * If [[Query::$orderBy]] parameter is not set, batches will be processed using the highly efficient "scan" mode.
+ * In this case, [[Query::$limit]] setting determines batch size per shard.
+ * See [elasticsearch guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html)
+ * for more information.
+ *
+ * Example:
+ * ```php
+ * $query = (new Query)->from('user');
+ * foreach ($query->batch() as $i => $users) {
+ *     // $users represents the rows in the $i-th batch
+ * }
+ * foreach ($query->each() as $user) {
+ * }
+ * ```
+ *
+ * @author Konstantin Sirotkin <beowulfenator@gmail.com>
+ * @since 2.0
+ */
+class BatchQueryResult extends BaseBatchQueryResult implements \Iterator
+{
+    /**
+     * @var string the amount of time to keep the scroll window open
+     * (in ElasticSearch [time units](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units).
+     */
+    public $scrollWindow = '1m';
+
+    /**
+     * @var array the data retrieved in the current batch
+     */
+    private $_batch = null;
+    /**
+     * @var mixed the value for the current iteration
+     */
+    private $_value = null;
+    /**
+     * @var string|integer the key for the current iteration
+     */
+    private $_key = null;
+    /*
+     * @var string internal ElasticSearch scroll id
+     */
+    private $_lastScrollId = null;
+
+    /**
+     * @inheritdoc
+     */
+    public function reset()
+    {
+        if(isset($this->_lastScrollId)) {
+            $this->query->createCommand($this->db)->clearScroll(['scroll_id' => $this->_lastScrollId]);
+        }
+
+        $this->_batch = null;
+        $this->_value = null;
+        $this->_key = null;
+        $this->_lastScrollId = null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function fetchData()
+    {
+        if (null === $this->_lastScrollId) {
+            //first query - do search
+            $options = ['scroll' => $this->scrollWindow];
+            if(!$this->query->orderBy) {
+                $options['search_type'] = 'scan';
+            }
+            $result = $this->query->createCommand($this->db)->search($options);
+
+            //if using "scan" mode, make another request immediately
+            //(search request returned 0 results)
+            if(!$this->query->orderBy) {
+                $result = $this->query->createCommand($this->db)->scroll([
+                    'scroll_id' => $result['_scroll_id'],
+                    'scroll' => $this->scrollWindow,
+                ]);
+            }
+        } else {
+            //subsequent queries - do scroll
+            $result = $this->query->createCommand($this->db)->scroll([
+                'scroll_id' => $this->_lastScrollId,
+                'scroll' => $this->scrollWindow,
+            ]);
+        }
+
+        //get last scroll id
+        $this->_lastScrollId = $result['_scroll_id'];
+
+        //get data
+        return $this->query->populate($result['hits']['hits']);
+    }
+
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Yii Framework 2 elasticsearch extension Change Log
 - Enh #28: AWS Elasticsearch service compatibility (andrey-bahrachev)
 - Enh #33: Implemented `Command::updateSettings()` and `Command::updateAnalyzers()` (githubjeka)
 - Enh #50: Implemented HTTP auth (silverfire)
+- Enh #62: Added support for scroll API in `batch()` and `each()` (beowulfenator)
+- Bug #48: `UpdateAll` now updates all entries, not first 10 (beowulfenator)
+- Bug #19: `DeleteAll` now deletes all entries, not first 10 (beowulfenator)
+- Enh: Unified model creation from result set in `Query` and `ActiveQuery` with `populate()` (beowulfenator)
 
 2.0.3 March 01, 2015
 --------------------

--- a/Command.php
+++ b/Command.php
@@ -377,6 +377,26 @@ class Command extends Component
     }
 
     /**
+     * @param array $options
+     * @see https://www.elastic.co/guide/en/elasticsearch/guide/current/scan-scroll.html
+     * @return mixed
+     */
+    public function scroll($options = [])
+    {
+       return $this->db->get(['_search', 'scroll'], $options);
+    }
+
+    /**
+     * @param array $options
+     * @see https://www.elastic.co/guide/en/elasticsearch/guide/current/scan-scroll.html
+     * @return mixed
+     */
+    public function clearScroll($options = [])
+    {
+       return $this->db->delete(['_search', 'scroll'], $options);
+    }
+
+    /**
      * @param $index
      * @return mixed
      * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-status.html

--- a/Command.php
+++ b/Command.php
@@ -378,8 +378,9 @@ class Command extends Component
 
     /**
      * @param array $options
-     * @see https://www.elastic.co/guide/en/elasticsearch/guide/current/scan-scroll.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
      * @return mixed
+     * @since 2.0.4
      */
     public function scroll($options = [])
     {
@@ -388,8 +389,9 @@ class Command extends Component
 
     /**
      * @param array $options
-     * @see https://www.elastic.co/guide/en/elasticsearch/guide/current/scan-scroll.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
      * @return mixed
+     * @since 2.0.4
      */
     public function clearScroll($options = [])
     {

--- a/Query.php
+++ b/Query.php
@@ -460,6 +460,65 @@ class Query extends Component implements QueryInterface
     }
 
     /**
+     * Starts a batch query.
+     *
+     * A batch query supports fetching data in batches, which can keep the memory usage under a limit.
+     * This method will return a [[BatchQueryResult]] object which implements the [[\Iterator]] interface
+     * and can be traversed to retrieve the data in batches.
+     *
+     * For example,
+     *
+     * ```php
+     * $query = (new Query)->from('user');
+     * foreach ($query->batch() as $rows) {
+     *     // $rows is an array of 10 or fewer rows from user table
+     * }
+     * ```
+     *
+     * @param integer $batchSize the number of records to be fetched in each batch.
+     * @param Connection $db the database connection. If not set, the "db" application component will be used.
+     * @return BatchQueryResult the batch query result. It implements the [[\Iterator]] interface
+     * and can be traversed to retrieve the data in batches.
+     */
+    public function batch($scrollWindow = '1m', $db = null)
+    {
+        return Yii::createObject([
+            'class' => BatchQueryResult::className(),
+            'query' => $this,
+            'scrollWindow' => $scrollWindow,
+            'db' => $db,
+            'each' => false,
+        ]);
+    }
+
+    /**
+     * Starts a batch query and retrieves data row by row.
+     * This method is similar to [[batch()]] except that in each iteration of the result,
+     * only one row of data is returned. For example,
+     *
+     * ```php
+     * $query = (new Query)->from('user');
+     * foreach ($query->each() as $row) {
+     * }
+     * ```
+     *
+     * @param integer $batchSize the number of records to be fetched in each batch.
+     * @param Connection $db the database connection. If not set, the "db" application component will be used.
+     * @return BatchQueryResult the batch query result. It implements the [[\Iterator]] interface
+     * and can be traversed to retrieve the data in batches.
+     */
+    public function each($scrollWindow = '1m', $db = null)
+    {
+        return Yii::createObject([
+            'class' => BatchQueryResult::className(),
+            'query' => $this,
+            'scrollWindow' => $scrollWindow,
+            'db' => $db,
+            'each' => true,
+        ]);
+    }
+
+    /**
      * Sets the filter part of this search query.
      * @param string $filter
      * @return $this the query object itself

--- a/Query.php
+++ b/Query.php
@@ -210,6 +210,7 @@ class Query extends Component implements QueryInterface
      * into the format as required by this query.
      * @param array $rows the raw query result from database
      * @return array the converted query result
+     * @since 2.0.4
      */
     public function populate($rows)
     {
@@ -479,6 +480,7 @@ class Query extends Component implements QueryInterface
      * @param Connection $db the database connection. If not set, the "db" application component will be used.
      * @return BatchQueryResult the batch query result. It implements the [[\Iterator]] interface
      * and can be traversed to retrieve the data in batches.
+     * @since 2.0.4
      */
     public function batch($scrollWindow = '1m', $db = null)
     {
@@ -506,6 +508,7 @@ class Query extends Component implements QueryInterface
      * @param Connection $db the database connection. If not set, the "db" application component will be used.
      * @return BatchQueryResult the batch query result. It implements the [[\Iterator]] interface
      * and can be traversed to retrieve the data in batches.
+     * @since 2.0.4
      */
     public function each($scrollWindow = '1m', $db = null)
     {

--- a/Query.php
+++ b/Query.php
@@ -201,6 +201,18 @@ class Query extends Component implements QueryInterface
             return [];
         }
         $rows = $result['hits']['hits'];
+        return $this->populate($rows);
+    }
+
+    /**
+     * Converts the raw query results into the format as specified by this query.
+     * This method is internally used to convert the data fetched from database
+     * into the format as required by this query.
+     * @param array $rows the raw query result from database
+     * @return array the converted query result
+     */
+    public function populate($rows)
+    {
         if ($this->indexBy === null) {
             return $rows;
         }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -24,6 +24,14 @@ class QueryTest extends TestCase
         $command->insert('yiitest', 'user', ['name' => 'user2', 'email' => 'user2@example.com', 'status' => 1], 2);
         $command->insert('yiitest', 'user', ['name' => 'user3', 'email' => 'user3@example.com', 'status' => 2], 3);
         $command->insert('yiitest', 'user', ['name' => 'user4', 'email' => 'user4@example.com', 'status' => 1], 4);
+        $command->insert('yiitest', 'user', ['name' => 'user5', 'email' => 'user5@example.com', 'status' => 1], 5);
+        $command->insert('yiitest', 'user', ['name' => 'user6', 'email' => 'user6@example.com', 'status' => 1], 6);
+        $command->insert('yiitest', 'user', ['name' => 'user7', 'email' => 'user7@example.com', 'status' => 2], 7);
+        $command->insert('yiitest', 'user', ['name' => 'user8', 'email' => 'user8@example.com', 'status' => 1], 8);
+        $command->insert('yiitest', 'user', ['name' => 'user9', 'email' => 'user9@example.com', 'status' => 1], 9);
+        $command->insert('yiitest', 'user', ['name' => 'usera', 'email' => 'user10@example.com', 'status' => 1], 10);
+        $command->insert('yiitest', 'user', ['name' => 'userb', 'email' => 'user11@example.com', 'status' => 2], 11);
+        $command->insert('yiitest', 'user', ['name' => 'userc', 'email' => 'user12@example.com', 'status' => 1], 12);
 
         $command->flushIndex();
     }
@@ -83,7 +91,7 @@ class QueryTest extends TestCase
         $this->assertArrayHasKey('_id', $result);
         $this->assertEquals(1, $result['_id']);
 
-        $result = $query->where(['name' => 'user5'])->one($this->getConnection());
+        $result = $query->where(['name' => 'user15'])->one($this->getConnection());
         $this->assertFalse($result);
     }
 
@@ -92,8 +100,8 @@ class QueryTest extends TestCase
         $query = new Query;
         $query->from('yiitest', 'user');
 
-        $results = $query->all($this->getConnection());
-        $this->assertEquals(4, count($results));
+        $results = $query->limit(100)->all($this->getConnection());
+        $this->assertEquals(12, count($results));
         $result = reset($results);
         $this->assertEquals(3, count($result['_source']));
         $this->assertArrayHasKey('status', $result['_source']);
@@ -118,10 +126,23 @@ class QueryTest extends TestCase
         $query = new Query;
         $query->from('yiitest', 'user');
 
-        $results = $query->indexBy('name')->all($this->getConnection());
-        $this->assertEquals(4, count($results));
+        $results = $query->limit(100)->indexBy('name')->all($this->getConnection());
+        $this->assertEquals(12, count($results));
         ksort($results);
-        $this->assertEquals(['user1', 'user2', 'user3', 'user4'], array_keys($results));
+        $this->assertEquals([
+            'user1',
+            'user2',
+            'user3',
+            'user4',
+            'user5',
+            'user6',
+            'user7',
+            'user8',
+            'user9',
+            'usera',
+            'userb',
+            'userc'
+        ], array_keys($results));
     }
 
     public function testScalar()
@@ -133,7 +154,7 @@ class QueryTest extends TestCase
         $this->assertEquals('user1', $result);
         $result = $query->where(['name' => 'user1'])->scalar('noname', $this->getConnection());
         $this->assertNull($result);
-        $result = $query->where(['name' => 'user5'])->scalar('name', $this->getConnection());
+        $result = $query->where(['name' => 'user15'])->scalar('name', $this->getConnection());
         $this->assertNull($result);
     }
 
@@ -142,11 +163,11 @@ class QueryTest extends TestCase
         $query = new Query;
         $query->from('yiitest', 'user');
 
-        $result = $query->orderBy(['name' => SORT_ASC])->column('name', $this->getConnection());
+        $result = $query->orderBy(['name' => SORT_ASC])->limit(4)->column('name', $this->getConnection());
         $this->assertEquals(['user1', 'user2', 'user3', 'user4'], $result);
         $result = $query->column('noname', $this->getConnection());
         $this->assertEquals([null, null, null, null], $result);
-        $result = $query->where(['name' => 'user5'])->scalar('name', $this->getConnection());
+        $result = $query->where(['name' => 'user15'])->scalar('name', $this->getConnection());
         $this->assertNull($result);
 
     }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -265,6 +265,9 @@ class QueryTest extends TestCase
     {
     }
 
+    /**
+     * @since 2.0.4
+     */
     public function testBatch()
     {
         $names = [


### PR DESCRIPTION
Hi!

I've implemented my own version of batch query for elasticsearch. It is consistent with other db classes. In other words, batch query processing is done with `batch()` and `each()` functions. Also, I've written some tests for this functionality.

I would love to see this commit merged into trunk, because then I shall be able to fix issues #48 and #19.