### PR TITLE
Bugs

### DIFF
--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -43,13 +43,5 @@ class ConnectionTest extends TestCase
         //Actual is 'customer%2Fexternal%2F1/_update'
         $this->assertEquals([$httpAddress, 'customer/external/1/_update'],
             $reflectedMethod->invoke($this->connection, ['customer/external/1', '_update',]));
-
-        //Actual is 'bank/_search?pretty&q=%2A'
-        $this->assertEquals([$httpAddress, 'bank/_search?pretty&q=*'],
-            $reflectedMethod->invoke($this->connection, 'bank/_search?pretty', ['q' => '*']));
-
-        //Actual is 'bank/_search?pretty&q=user%3Akimchy'
-        $this->assertEquals([$httpAddress, 'bank/_search?pretty&q=*'],
-            $reflectedMethod->invoke($this->connection, 'bank/_search?pretty', ['q' => 'user:kimchy']));
     }
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -39,5 +39,17 @@ class ConnectionTest extends TestCase
 
         $this->assertEquals([$httpAddress, 'customer/external/1/_update'],
             $reflectedMethod->invoke($this->connection, ['customer', 'external', 1, '_update',]));
+
+        //Actual is 'customer%2Fexternal%2F1/_update'
+        $this->assertEquals([$httpAddress, 'customer/external/1/_update'],
+            $reflectedMethod->invoke($this->connection, ['customer/external/1', '_update',]));
+
+        //Actual is 'bank/_search?pretty&q=%2A'
+        $this->assertEquals([$httpAddress, 'bank/_search?pretty&q=*'],
+            $reflectedMethod->invoke($this->connection, 'bank/_search?pretty', ['q' => '*']));
+
+        //Actual is 'bank/_search?pretty&q=user%3Akimchy'
+        $this->assertEquals([$httpAddress, 'bank/_search?pretty&q=*'],
+            $reflectedMethod->invoke($this->connection, 'bank/_search?pretty', ['q' => 'user:kimchy']));
     }
 }


### PR DESCRIPTION
Now `Connection::createUrl()` support array and string `path`, but expected things behave incorrectly.

It is necessary to support arrays?