### PR TITLE
updated debug panel classes to be consistent with yii 2.0.7

### DIFF
--- a/DebugPanel.php
+++ b/DebugPanel.php
@@ -56,9 +56,9 @@ class DebugPanel extends Panel
         $queryTime = number_format($queryTime * 1000) . ' ms';
         $url = $this->getUrl();
         $output = <<<EOD
-<div class="yii-debug-toolbar-block">
+<div class="yii-debug-toolbar__block">
     <a href="$url" title="Executed $queryCount elasticsearch queries which took $queryTime.">
-        ES <span class="label">$queryCount</span> <span class="label">$queryTime</span>
+        ES <span class="yii-debug-toolbar__label yii-debug-toolbar__label_info">$queryCount</span> <span class="yii-debug-toolbar__label">$queryTime</span>
     </a>
 </div>
 EOD;


### PR DESCRIPTION
Is it OK to update these classes? Without them this toolbar panel looks broken in yii 2.0.7.