### PR TITLE
Bulk command API

### DIFF
--- a/BulkCommand.php
+++ b/BulkCommand.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\elasticsearch;
+
+use yii\base\Component;
+use yii\base\InvalidCallException;
+use yii\helpers\Json;
+
+/**
+ * The BulkCommand class implements the API for accessing the elasticsearch bulk REST API.
+ *
+ * Further details on bulk API is available in
+ * [elasticsearch guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html).
+ *
+ * @author Konstantin Sirotkin <beowulfenator@gmail.com>
+ * @since 2.0.5
+ */
+class BulkCommand extends Component
+{
+    /**
+     * @var Connection
+     */
+    public $db;
+    /**
+     * @var string Default index to execute the queries on. Defaults to null meaning that index needs to be specified in every action.
+     */
+    public $index;
+    /**
+     * @var string Default type to execute the queries on. Defaults to null meaning that type needs to be specified in every action.
+     */
+    public $type;
+    /**
+     * @var array|string Actions to be executed in this bulk command, given as either an array of arrays or as one newline-delimited string.
+     * All actions except delete span two lines.
+     */
+    public $actions;
+    /**
+     * @var array Options to be appended to the query URL.
+     */
+    public $options = [];
+
+    /**
+     * Executes the bulk command.
+     * @return mixed
+     * @throws yii\base\InvalidCallException
+     */
+    public function execute()
+    {
+        //valid endpoints are /_bulk, /{index}/_bulk, and {index}/{type}/_bulk
+        if (null === $this->index && null === $this->type) {
+            $endpoint = ['_bulk'];
+        } elseif (null !== $this->index && null === $this->type) {
+            $endpoint = [$this->index, '_bulk'];
+        } elseif (null !== $this->index && null !== $this->type) {
+            $endpoint = [$this->index, $this->type, '_bulk'];
+        } else {
+            throw new InvalidCallException('Invalid endpoint: if type is defined, index must be defined too.');
+        }
+
+        if (empty($this->actions)) {
+            $body = '{}';
+        } elseif (is_array($this->actions)) {
+            $body = '';
+            foreach ($this->actions as $action) {
+                $body .= Json::encode($action)."\n";
+            }
+        } else {
+            $body = $this->actions;
+        }
+
+        return $this->db->post($endpoint, $this->options, $body);
+    }
+
+    /**
+     * Adds an action to the command. Will overwrite existing actions if they are specified as a string.
+     * @param array $action Action expressed as an array (will be encoded to JSON automatically).
+     */
+    public function addAction($line1, $line2 = null)
+    {
+        if (!is_array($this->actions)) {
+            $this->actions = [];
+        }
+
+        $this->actions[] = $line1;
+
+        if (null !== $line2) {
+            $this->actions[] = $line2;
+        }
+    }
+
+    /**
+     * Adds a delete action to the command.
+     * @param string $index Index that the document belogs to. Can be set to null if the command has
+     * a default index ([[BulkCommand::$index]]) assigned.
+     * @param string $type Type that the document belogs to. Can be set to null if the command has
+     * a default type ([[BulkCommand::$type]]) assigned.
+     * @param string $id Document ID
+     */
+    public function addDeleteAction($id, $index = null, $type = null)
+    {
+        $actionData = ['_id' => $id];
+
+        if (!empty($index)) {
+            $actionData['_index'] = $index;
+        }
+
+        if (!empty($type)) {
+            $actionData['_type'] = $type;
+        }
+
+        $this->addAction(['delete' => $actionData]);
+    }
+}

--- a/BulkCommand.php
+++ b/BulkCommand.php
@@ -12,7 +12,7 @@ use yii\base\InvalidCallException;
 use yii\helpers\Json;
 
 /**
- * The BulkCommand class implements the API for accessing the elasticsearch bulk REST API.
+ * The [[BulkCommand]] class implements the API for accessing the elasticsearch bulk REST API.
  *
  * Further details on bulk API is available in
  * [elasticsearch guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html).
@@ -52,11 +52,11 @@ class BulkCommand extends Component
     public function execute()
     {
         //valid endpoints are /_bulk, /{index}/_bulk, and {index}/{type}/_bulk
-        if (null === $this->index && null === $this->type) {
+        if ($this->index === null && $this->type === null) {
             $endpoint = ['_bulk'];
-        } elseif (null !== $this->index && null === $this->type) {
+        } elseif ($this->index !== null && $this->type === null) {
             $endpoint = [$this->index, '_bulk'];
-        } elseif (null !== $this->index && null !== $this->type) {
+        } elseif ($this->index !== null && $this->type !== null) {
             $endpoint = [$this->index, $this->type, '_bulk'];
         } else {
             throw new InvalidCallException('Invalid endpoint: if type is defined, index must be defined too.');
@@ -67,7 +67,7 @@ class BulkCommand extends Component
         } elseif (is_array($this->actions)) {
             $body = '';
             foreach ($this->actions as $action) {
-                $body .= Json::encode($action)."\n";
+                $body .= Json::encode($action) . "\n";
             }
         } else {
             $body = $this->actions;
@@ -88,18 +88,18 @@ class BulkCommand extends Component
 
         $this->actions[] = $line1;
 
-        if (null !== $line2) {
+        if ($line2 !== null) {
             $this->actions[] = $line2;
         }
     }
 
     /**
      * Adds a delete action to the command.
+     * @param string $id Document ID
      * @param string $index Index that the document belogs to. Can be set to null if the command has
      * a default index ([[BulkCommand::$index]]) assigned.
      * @param string $type Type that the document belogs to. Can be set to null if the command has
      * a default type ([[BulkCommand::$type]]) assigned.
-     * @param string $id Document ID
      */
     public function addDeleteAction($id, $index = null, $type = null)
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Yii Framework 2 elasticsearch extension Change Log
 - Enh #15: Special data provider `yii\elasticsearch\ActiveDataProvider` created (klimov-paul)
 - Enh #60: Minor updates to guide (devypt, beowulfenator)
 - Enh #83: Support for "gt", ">", "gte", ">=", "lt", "<", "lte", "<=" operators in query (i-lie, beowulfenator)
-
+- Enh: Bulk API implemented and used in AR (tibee, beowulfenator)
 
 2.0.4 March 17, 2016
 --------------------

--- a/Connection.php
+++ b/Connection.php
@@ -231,6 +231,21 @@ class Connection extends Component
     }
 
     /**
+     * Creates a bulk command for execution.
+     * @param array $config the configuration for the BulkCommand class
+     * @return BulkCommand the DB command
+     * @since 2.0.5
+     */
+    public function createBulkCommand($config = [])
+    {
+        $this->open();
+        $config['db'] = $this;
+        $command = new BulkCommand($config);
+
+        return $command;
+    }
+
+    /**
      * Creates new query builder instance
      * @return QueryBuilder
      */

--- a/Connection.php
+++ b/Connection.php
@@ -232,7 +232,7 @@ class Connection extends Component
 
     /**
      * Creates a bulk command for execution.
-     * @param array $config the configuration for the BulkCommand class
+     * @param array $config the configuration for the [[BulkCommand]] class
      * @return BulkCommand the DB command
      * @since 2.0.5
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

My implementation of Bulk command API. Typical usage:

```php
$bulkCommand = $db->createBulkCommand();
$bulkCommand->addAction(["update" => [/* ... */], ["doc" => /* ... */]]);
$bulkCommand->addDeleteAction(123, 'my_index', 'my_type');
$bulkCommand->addDeleteAction(456, 'my_index', 'my_other_type');
$result = $bulkCommand->execute();
```

Methods like `addUpdateAction`, `addIndexAction`, and `addCreateAction` could be implemented later if necessary (but I doubt we can make them more convenient than the generic `addAction` method, so I wouldn't bother).