### PR TITLE
Allow to connect to ES cluster using HTTPS

### DIFF
--- a/tests/ElasticSearchConnectionTest.php
+++ b/tests/ElasticSearchConnectionTest.php
@@ -13,8 +13,9 @@ class ElasticSearchConnectionTest extends TestCase
     {
         $connection = new Connection();
         $connection->autodetectCluster;
+        $config = require "data/config.php";
         $connection->nodes = [
-            ['http_address' => 'inet[/127.0.0.1:9200]'],
+            ['http_address' => $config['elasticsearch']['nodes'][0]['http_address']],
         ];
         $this->assertNull($connection->activeNode);
         $connection->open();

--- a/tests/ElasticSearchConnectionTest.php
+++ b/tests/ElasticSearchConnectionTest.php
@@ -2,6 +2,7 @@
 
 namespace yiiunit\extensions\elasticsearch;
 
+use PHPUnit_Framework_MockObject_MockObject;
 use yii\elasticsearch\Connection;
 
 /**
@@ -13,16 +14,56 @@ class ElasticSearchConnectionTest extends TestCase
     {
         $connection = new Connection();
         $connection->autodetectCluster;
-        $config = require "data/config.php";
+        $config            = require "data/config.php";
         $connection->nodes = [
             ['http_address' => $config['elasticsearch']['nodes'][0]['http_address']],
         ];
         $this->assertNull($connection->activeNode);
+        $connection->init();
         $connection->open();
         $this->assertNotNull($connection->activeNode);
         $this->assertArrayHasKey('name', reset($connection->nodes));
 //        $this->assertArrayHasKey('hostname', reset($connection->nodes));
         $this->assertArrayHasKey('version', reset($connection->nodes));
         $this->assertArrayHasKey('http_address', reset($connection->nodes));
+    }
+
+    /**
+     * @dataProvider getPossibleHttpAddresses
+     */
+    public function testPopulateNodesUsesCorrectProtocol($httpAddress, $expectedUrl)
+    {
+        /**
+         * @var Connection|PHPUnit_Framework_MockObject_MockObject $connection
+         */
+        $connection = $this->getMockBuilder(Connection::className())
+            ->disableOriginalConstructor()
+            ->setMethods(['httpRequest'])
+            ->getMock();
+
+        $connection->autodetectCluster = true;
+        $connection->nodes             = [
+            ['http_address' => $httpAddress]
+        ];
+        $connection->init();
+
+        $reflectedMethod = new \ReflectionMethod($connection, 'populateNodes');
+        $reflectedMethod->setAccessible(true);
+
+        $connection->expects($this->once())
+            ->method("httpRequest")
+            ->with('GET', $expectedUrl)
+            ->willReturn(['nodes' => $connection->nodes]);
+
+        $reflectedMethod->invoke($connection);
+    }
+
+    public function getPossibleHttpAddresses()
+    {
+        return [
+            'Regular HTTP'                 => ['test', 'http://test/_nodes'],
+            'HTTPS'                        => ['https://test', 'https://test/_nodes'],
+            'HTTP with protocol specified' => ['http://test', 'http://test/_nodes'],
+        ];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -99,6 +99,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     {
         $config = self::getParam('elasticsearch');
         $db = new Connection($config);
+        $db->init();
         if ($reset) {
             $db->open();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #82

Useful when connecting to Elasticsearch hosts with HTTPS-only access.
User can enter https://{hostname} as http_address.
