### PR TITLE
added accessor for default primary key

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -262,16 +262,6 @@ class ActiveRecord extends BaseActiveRecord
     }
 
     /**
-     * Accessor method for getting the default primary key.
-     *
-     * @return mixed the value of the primary key
-     */
-    public function get_id()
-    {
-        return $this->_id;
-    }
-
-    /**
      * Returns the list of all attribute names of the model.
      *
      * This method must be overridden by child classes to define available attributes.

--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -262,6 +262,16 @@ class ActiveRecord extends BaseActiveRecord
     }
 
     /**
+     * Accessor method for getting the default primary key.
+     *
+     * @return mixed the value of the primary key
+     */
+    public function get_id()
+    {
+        return $this->_id;
+    }
+
+    /**
      * Returns the list of all attribute names of the model.
      *
      * This method must be overridden by child classes to define available attributes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 elasticsearch extension Change Log
 - Enh: Bulk API implemented and used in AR (tibee, beowulfenator)
 - Enh #82: Support HTTPS protocol (dor-denis, beowulfenator)
 - Enh #43: Elasticsearch log target (trntv, beowulfenator)
+- Bug: Added accessor method for the default elasticsearch primary key (kyle-mccarthy)
 
 
 2.0.4 March 17, 2016


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

If a model extending the ActiveRecord class does not implement the primaryKey function, the primary key will default to '_id'.  However, this property is inaccessible as it is private, resulting in an UnknownPropertyException.  The accessibility of the property would need to be changed to protected, or an accessor method would need to be implemented (which I chose). 

To reproduce the bug that this PR fixes:

1. Create a new model and extend the ActiveRecord
2. Use the default primary key (_id)/don't override the primaryKey method
3. Attempt to use ActiveDataProvider 

