### PR TITLE
Elasticsearch 5.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,21 +8,26 @@ php:
   - hhvm
 
 services:
-  - elasticsearch
+  - docker
 
 # faster builds on new travis setup not using sudo
-sudo: false
+sudo: required
 
 # cache vendor dirs
 cache:
   directories:
     - $HOME/.composer/cache
 
+before_install:
+  - docker pull elasticsearch:5.1
+  - docker run -p 9200:9200 -d elasticsearch:5.1 -Etransport.host=127.0.0.1 -Ehttp.publish_host=127.0.0.1
+
 install:
   - travis_retry composer self-update && composer --version
+  - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
   - travis_retry composer global require "fxp/composer-asset-plugin:~1.1.1"
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
-  - travis_retry composer install --prefer-dist --no-interaction
+  - travis_retry composer install --prefer-source --no-interaction
 
 before_script:
   - echo 'elasticsearch version ' && curl http://localhost:9200/

--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -662,9 +662,15 @@ class ActiveRecord extends BaseActiveRecord
         foreach ($primaryKeys as $pk) {
             $script = '';
             foreach ($counters as $counter => $value) {
-                $script .= "ctx._source.{$counter} += {$counter};\n";
+                $script .= "ctx._source.{$counter} += params.{$counter};\n";
             }
-            $bulkCommand->addAction(["update" => ["_id" => $pk]], ["script" => $script, "params" => $counters, "lang" => "groovy"]);
+            $bulkCommand->addAction(["update" => ["_id" => $pk]], [
+                'script' => [
+                    'inline' => $script,
+                    'params' => $counters,
+                    'lang' => 'painless',
+                ],
+            ]);
         }
         $response = $bulkCommand->execute();
 

--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -415,7 +415,7 @@ class ActiveRecord extends BaseActiveRecord
      * By default the `op_type` is set to `create`.
      * @return boolean whether the attributes are valid and the record is inserted successfully.
      */
-    public function insert($runValidation = true, $attributes = null, $options = ['op_type' => 'create'])
+    public function insert($runValidation = true, $attributes = null)
     {
         if ($runValidation && !$this->validate($attributes)) {
             return false;
@@ -424,6 +424,8 @@ class ActiveRecord extends BaseActiveRecord
             return false;
         }
         $values = $this->getDirtyAttributes($attributes);
+
+        $options = $this->getPrimaryKey() !== null ? [ 'op_type' => 'create' ] : [ ];
 
         $response = static::getDb()->createCommand()->insert(
             static::index(),

--- a/BatchQueryResult.php
+++ b/BatchQueryResult.php
@@ -153,18 +153,13 @@ class BatchQueryResult extends Object implements \Iterator
             //first query - do search
             $options = ['scroll' => $this->scrollWindow];
             if(!$this->query->orderBy) {
-                $options['search_type'] = 'scan';
+                $query = clone $this->query;
+                $query->orderBy('_doc');
+                $cmd = $this->query->createCommand($this->db);
+            } else {
+                $cmd = $this->query->createCommand($this->db);
             }
-            $result = $this->query->createCommand($this->db)->search($options);
-
-            //if using "scan" mode, make another request immediately
-            //(search request returned 0 results)
-            if(!$this->query->orderBy) {
-                $result = $this->query->createCommand($this->db)->scroll([
-                    'scroll_id' => $result['_scroll_id'],
-                    'scroll' => $this->scrollWindow,
-                ]);
-            }
+            $result = $cmd->search($options);
         } else {
             //subsequent queries - do scroll
             $result = $this->query->createCommand($this->db)->scroll([

--- a/Command.php
+++ b/Command.php
@@ -482,17 +482,6 @@ class Command extends Component
 
     /**
      * @param $index
-     * @param $type
-     * @return mixed
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html
-     */
-    public function deleteMapping($index, $type)
-    {
-        return $this->db->delete([$index, '_mapping', $type]);
-    }
-
-    /**
-     * @param $index
      * @param string $type
      * @return mixed
      * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-field-mapping.html

--- a/Connection.php
+++ b/Connection.php
@@ -540,7 +540,7 @@ class Connection extends Component
         } elseif ($responseCode == 404) {
             return false;
         } else {
-            throw new Exception("Elasticsearch request failed with code $responseCode.", [
+            throw new Exception("Elasticsearch request failed with code $responseCode. Response body:\n{$body}", [
                 'requestMethod' => $method,
                 'requestUrl' => $url,
                 'requestBody' => $requestBody,

--- a/Connection.php
+++ b/Connection.php
@@ -560,6 +560,7 @@ class Connection extends Component
             CURLOPT_WRITEFUNCTION => null,
             CURLOPT_READFUNCTION => null,
             CURLOPT_PROGRESSFUNCTION => null,
+            CURLOPT_POSTFIELDS => null,
         ];
         curl_setopt_array($this->_curl, $unsetValues);
         if (function_exists('curl_reset')) { // since PHP 5.5.0

--- a/Connection.php
+++ b/Connection.php
@@ -173,7 +173,7 @@ class Connection extends Component
         if (strncmp($host, 'inet[/', 6) === 0) {
             $host = substr($host, 6, -1);
         }
-        $response = $this->httpRequest('GET', "$protocol://$host/_nodes");
+        $response = $this->httpRequest('GET', "$protocol://$host/_nodes/_all/http");
         if (!empty($response['nodes'])) {
             $nodes = $response['nodes'];
         } else {
@@ -184,9 +184,10 @@ class Connection extends Component
             // Make sure that nodes have an 'http_address' property, which is not the case if you're using AWS
             // Elasticsearch service (at least as of Oct., 2015). - TO BE VERIFIED
             // Temporary workaround - simply ignore all invalid nodes
-            if (!isset($node['http_address'])) {
+            if (!isset($node['http']['publish_address'])) {
                 unset($nodes[$key]);
             }
+            $node['http_address'] = $node['http']['publish_address'];
 
             //Protocol is not a standard ES node property, so we add it manually
             $node['protocol'] = $this->defaultProtocol;
@@ -219,7 +220,7 @@ class Connection extends Component
             return;
         }
         Yii::trace('Closing connection to elasticsearch. Active node was: '
-            . $this->nodes[$this->activeNode]['http_address'], __CLASS__);
+            . $this->nodes[$this->activeNode]['http']['publish_address'], __CLASS__);
         $this->activeNode = null;
         if ($this->_curl) {
             curl_close($this->_curl);

--- a/Query.php
+++ b/Query.php
@@ -26,7 +26,7 @@ use yii\db\QueryTrait;
  *
  * ~~~
  * $query = new Query;
- * $query->fields('id, name')
+ * $query->storedFields('id, name')
  *     ->from('myindex', 'users')
  *     ->limit(10);
  * // build and execute the query
@@ -62,13 +62,22 @@ class Query extends Component implements QueryInterface
      * In this case the `_source` field will be returned by default which can be configured using [[source]].
      * Setting this to an empty array will result in no fields being retrieved, which means that only the primaryKey
      * of a record will be available in the result.
+     * > Note: Field values are [always returned as arrays] even if they only have one value.
      *
-     * For each field you may also add an array representing a [script field]. Example:
+     * [always returned as arrays]: http://www.elastic.co/guide/en/elasticsearch/reference/1.x/_return_values.html#_return_values
+     * [script field]: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-script-fields.html
      *
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-stored-fields.html
+     * @see storedFields()
+     * @see source
+     */
+    public $storedFields;
+
+	/**
+	 * @var array the scripted fields being retrieved from the documents.
+	 * Example:
      * ```php
-     * $query->fields = [
-     *     'id',
-     *     'name',
+     * $query->scriptFields = [
      *     'value_times_two' => [
      *         'script' => "doc['my_field_name'].value * 2",
      *     ],
@@ -80,18 +89,18 @@ class Query extends Component implements QueryInterface
      *     ],
      * ]
      * ```
-     *
+	 *
      * > Note: Field values are [always returned as arrays] even if they only have one value.
-     *
+	 *
      * [always returned as arrays]: http://www.elastic.co/guide/en/elasticsearch/reference/1.x/_return_values.html#_return_values
      * [script field]: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-script-fields.html
-     *
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-fields.html#search-request-fields
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-script-fields.html
-     * @see fields()
+	 *
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-script-fields.html
+     * @see scriptFields()
      * @see source
-     */
-    public $fields;
+	 */
+	public $scriptFields;
+
     /**
      * @var array this option controls how the `_source` field is returned from the documents. For example, `['id', 'name']`
      * means that only the `id` and `name` field should be returned from `_source`.
@@ -574,16 +583,37 @@ class Query extends Component implements QueryInterface
 
     /**
      * Sets the fields to retrieve from the documents.
+	 * > Quote from the elasticsearch doc:
+	 * > The stored_fields parameter is about fields that are explicitly marked
+	 * > as stored in the mapping, which is off by default and generally not recommended.
+	 * > Use source filtering instead to select subsets of the original source document to be returned.
+	 * 
      * @param array $fields the fields to be selected.
      * @return $this the query object itself
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-fields.html
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-stored-fields.html
      */
-    public function fields($fields)
+    public function storedFields($fields)
     {
         if (is_array($fields) || $fields === null) {
-            $this->fields = $fields;
+            $this->storedFields = $fields;
         } else {
-            $this->fields = func_get_args();
+            $this->storedFields = func_get_args();
+        }
+        return $this;
+    }
+
+    /**
+     * Sets the script fields to retrieve from the documents.
+     * @param array $fields the fields to be selected.
+     * @return $this the query object itself
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-script-fields.html
+     */
+    public function scriptFields($fields)
+    {
+        if (is_array($fields) || $fields === null) {
+            $this->scriptFields = $fields;
+        } else {
+            $this->scriptFields = func_get_args();
         }
         return $this;
     }

--- a/Query.php
+++ b/Query.php
@@ -377,7 +377,7 @@ class Query extends Component implements QueryInterface
         // http://www.elastic.co/guide/en/elasticsearch/reference/1.x/_search_requests.html
 
         $options = [];
-        $options['search_type'] = 'count';
+        $options['size'] = 0;
 
         return $this->createCommand($db)->search($options)['hits']['total'];
     }

--- a/Query.php
+++ b/Query.php
@@ -696,6 +696,36 @@ class Query extends Component implements QueryInterface
     }
 
     /**
+     * @inheritdoc
+     */
+    public function andWhere($condition)
+    {
+        if ($this->where === null) {
+            $this->where = $condition;
+        } else if (isset($this->where[0]) && $this->where[0] == 'and') {
+            $this->where[] = $condition;
+        } else {
+            $this->where = ['and', $this->where, $condition];
+        }
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function orWhere($condition)
+    {
+        if ($this->where === null) {
+            $this->where = $condition;
+        } else if (isset($this->where[0]) && $this->where[0] == 'or') {
+            $this->where[] = $condition;
+        } else {
+            $this->where = ['or', $this->where, $condition];
+        }
+        return $this;
+    }
+
+    /**
      * Set the `post_filter` part of the search query.
      * @param string|array $filter
      * @return $this the query object itself

--- a/Query.php
+++ b/Query.php
@@ -557,17 +557,6 @@ class Query extends Component implements QueryInterface
     }
 
     /**
-     * Sets the filter part of this search query.
-     * @param string $filter
-     * @return $this the query object itself
-     */
-    public function filter($filter)
-    {
-        $this->filter = $filter;
-        return $this;
-    }
-
-    /**
      * Sets the index and type to retrieve documents from.
      * @param string|array $index The index to retrieve data from. This can be a string representing a single index
      * or a an array of multiple indexes. If this is `null` it means that all indexes are being queried.

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -236,16 +236,12 @@ class QueryBuilder extends \yii\base\Object
                 }
             }
         }
-        if ($emptyFields) {
-            return [
-                'bool' => [
-                    'must' => $parts,
-                    'must_not' => $emptyFields,
-                ],
-            ];
-        } else {
-            return $parts;
-        }
+        return [
+            'bool' => [
+                'must' => $parts,
+                'must_not' => $emptyFields,
+            ],
+        ];
     }
 
     private function buildNotCondition($operator, $operands)

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -152,12 +152,16 @@ class QueryBuilder extends \yii\base\Object
 
     public function buildQueryFromWhere($condition) {
         $where = $this->buildCondition($condition);
-        $query = [
-            'constant_score' => [
-                'filter' => $where,
-            ],
-        ];
-        return $query;
+        if ($where) {
+            $query = [
+                'constant_score' => [
+                    'filter' => $where,
+                ],
+            ];
+            return $query;
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -269,10 +273,12 @@ class QueryBuilder extends \yii\base\Object
                 $parts[] = $operand;
             }
         }
-        if (!empty($parts)) {
-            return [$operator => $parts];
-        } else {
-            return [];
+        if ($parts) {
+            return [
+                'bool' => [
+                    'must' => $parts,
+                ]
+            ];
         }
     }
 

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -228,12 +228,12 @@ class QueryBuilder extends \yii\base\Object
                 }
             }
         }
-        return [
-            'bool' => [
-                'must' => $parts,
-                'must_not' => $emptyFields,
-            ],
-        ];
+
+        $query = [ 'must' => $parts ];
+        if ($emptyFields) {
+            $query['must_not'] = $emptyFields;
+        }
+        return [ 'bool' => $query ];
     }
 
     private function buildNotCondition($operator, $operands)
@@ -304,8 +304,8 @@ class QueryBuilder extends \yii\base\Object
 
     private function buildInCondition($operator, $operands)
     {
-        if (!isset($operands[0], $operands[1])) {
-            throw new InvalidParamException("Operator '$operator' requires two operands.");
+        if (!isset($operands[0], $operands[1]) || !is_array($operands)) {
+            throw new InvalidParamException("Operator '$operator' requires array of two operands: column and values");
         }
 
         list($column, $values) = $operands;

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -46,25 +46,13 @@ class QueryBuilder extends \yii\base\Object
     {
         $parts = [];
 
-        if ($query->fields === []) {
-            $parts['fields'] = [];
-        } elseif ($query->fields !== null) {
-            $fields = [];
-            $scriptFields = [];
-            foreach ($query->fields as $key => $field) {
-                if (is_int($key)) {
-                    $fields[] = $field;
-                } else {
-                    $scriptFields[$key] = $field;
-                }
-            }
-            if (!empty($fields)) {
-                $parts['fields'] = $fields;
-            }
-            if (!empty($scriptFields)) {
-                $parts['script_fields'] = $scriptFields;
-            }
+        if ($query->storedFields !== null) {
+            $parts['stored_fields'] = $query->storedFields;
         }
+        if ($query->scriptFields !== null) {
+            $parts['script_fields'] = $query->scriptFields;
+        }
+
         if ($query->source !== null) {
             $parts['_source'] = $query->source;
         }

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -176,8 +176,8 @@ class QueryBuilder extends \yii\base\Object
     {
         static $builders = [
             'not' => 'buildNotCondition',
-            'and' => 'buildAndCondition',
-            'or' => 'buildAndCondition',
+            'and' => 'buildBoolCondition',
+            'or' => 'buildBoolCondition',
             'between' => 'buildBetweenCondition',
             'not between' => 'buildBetweenCondition',
             'in' => 'buildInCondition',
@@ -262,9 +262,17 @@ class QueryBuilder extends \yii\base\Object
         return [$operator => $operand];
     }
 
-    private function buildAndCondition($operator, $operands)
+    private function buildBoolCondition($operator, $operands)
     {
         $parts = [];
+        if ($operator == 'and') {
+            $clause = 'must';
+        } else if ($operator == 'or') {
+            $clause = 'should';
+        } else {
+            throw InvalidParamExcepton("Operator should be 'or' or 'and'");
+        }
+
         foreach ($operands as $operand) {
             if (is_array($operand)) {
                 $operand = $this->buildCondition($operand);
@@ -276,9 +284,11 @@ class QueryBuilder extends \yii\base\Object
         if ($parts) {
             return [
                 'bool' => [
-                    'must' => $parts,
+                    $clause => $parts,
                 ]
             ];
+        } else {
+            return null;
         }
     }
 

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -78,27 +78,18 @@ class QueryBuilder extends \yii\base\Object
             $parts['min_score'] = (float)$query->minScore;
         }
 
-        if (empty($query->query)) {
-            $parts['query'] = ["match_all" => (object)[]];
-        } else {
-            $parts['query'] = $query->query;
-        }
-
         $whereFilter = $this->buildCondition($query->where);
-        if (is_string($query->filter)) {
-            if (empty($whereFilter)) {
-                $parts['filter'] = $query->filter;
-            } else {
-                $parts['filter'] = '{"and": [' . $query->filter . ', ' . Json::encode($whereFilter) . ']}';
-            }
-        } elseif ($query->filter !== null) {
-            if (empty($whereFilter)) {
-                $parts['filter'] = $query->filter;
-            } else {
-                $parts['filter'] = ['and' => [$query->filter, $whereFilter]];
-            }
-        } elseif (!empty($whereFilter)) {
-            $parts['filter'] = $whereFilter;
+        if ($whereFilter) {
+            $parts['query'] = [
+                'bool' => [
+                    'query' => empty($query->query) ? [ 'match_all' => (object)[] ] : $query->query,
+                    'filter' => $whereFilter,
+                ],
+            ];
+        } else if ($query->query) {
+            $parts['query'] = $query->query;
+        } else {
+            $parts['query'] = [ "match_all" => (object)[] ];
         }
 
         if (!empty($query->highlight)) {

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -452,14 +452,14 @@ class ActiveRecordTest extends TestCase
 
     public function testScriptFields()
     {
-        $orderItems = OrderItem::find()->fields([
-                    'quantity',
-                    'subtotal',
-                    'total' => [
-                        'script' => "doc['quantity'].value * doc['subtotal'].value",
-                        'lang' => 'groovy',
-                    ]
-                ])->all();
+        $orderItems = OrderItem::find()
+            ->storedFields('quantity', 'subtotal')
+            ->scriptFields([
+                'total' => [
+                    'script' => "doc['quantity'].value * doc['subtotal'].value",
+                    'lang' => 'groovy',
+                ]
+            ])->all();
         $this->assertNotEmpty($orderItems);
         foreach ($orderItems as $item) {
             $this->assertEquals($item->subtotal * $item->quantity, $item->total);
@@ -470,7 +470,8 @@ class ActiveRecordTest extends TestCase
     {
         /* @var $this TestCase|ActiveRecordTestTrait */
         // indexBy + asArray
-        $customers = Customer::find()->asArray()->fields(['id', 'name'])->all();
+        $customers = Customer::find()->asArray()
+            ->storedFields(['id', 'name'])->all();
         $this->assertEquals(3, count($customers));
         $this->assertArrayHasKey('id', $customers[0]['fields']);
         $this->assertArrayHasKey('name', $customers[0]['fields']);

--- a/tests/ElasticsearchTargetTest.php
+++ b/tests/ElasticsearchTargetTest.php
@@ -22,6 +22,7 @@ class ElasticsearchTargetTest extends TestCase
 
         $logger->log('Test message', Logger::LEVEL_INFO, 'test-category');
         $logger->flush(true);
+        $this->getConnection()->createCommand()->refreshIndex($this->index);
 
         $query = new Query();
         $query->from($this->index, $this->type);
@@ -55,9 +56,6 @@ class ElasticsearchTargetTest extends TestCase
                     'db' => $this->getConnection(),
                     'index' => $this->index,
                     'type' => $this->type,
-                    'options' => [
-                        'refresh' => true
-                    ]
                 ]
             ]
         ]);

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -19,10 +19,14 @@ class QueryTest extends TestCase
         if ($command->indexExists('yiitest')) {
             $command->deleteIndex('yiitest');
         }
-        /* FIXME: setup proper mapping for an index?
-         * elasticsearch autocreates field and field.keyword field
-         * for text fields
-         */
+
+        $command->setMapping('yiitest', 'user', [
+            'properties' => [
+                'name' => [ 'type' => 'keyword', 'store' => true ],
+                'email' => [ 'type' => 'keyword', 'store' => true ],
+                'status' => [ 'type' => 'integer' ],
+            ],
+        ]);
 
         $command->insert('yiitest', 'user', ['name' => 'user1', 'email' => 'user1@example.com', 'status' => 1], 1);
         $command->insert('yiitest', 'user', ['name' => 'user2', 'email' => 'user2@example.com', 'status' => 1], 2);
@@ -167,7 +171,7 @@ class QueryTest extends TestCase
         $query = new Query;
         $query->from('yiitest', 'user');
 
-        $result = $query->orderBy(['name.keyword' => SORT_ASC])->limit(4)->column('name', $this->getConnection());
+        $result = $query->orderBy(['name' => SORT_ASC])->limit(4)->column('name', $this->getConnection());
         $this->assertEquals(['user1', 'user2', 'user3', 'user4'], $result);
         $result = $query->column('noname', $this->getConnection());
         $this->assertEquals([null, null, null, null], $result);
@@ -312,7 +316,7 @@ class QueryTest extends TestCase
 
         //test each
         $query = new Query;
-        $query->from('yiitest', 'user')->limit(3)->orderBy(['name.keyword' => SORT_ASC])->indexBy('name')->options(['preference' => '_local']);
+        $query->from('yiitest', 'user')->limit(3)->orderBy(['name' => SORT_ASC])->indexBy('name')->options(['preference' => '_local']);
         //NOTE: preference -> _local has no influence on query result, everything's fine as long as query doesn't fail
 
         $result_keys = [];
@@ -330,7 +334,7 @@ class QueryTest extends TestCase
 
         //test batch
         $query = new Query;
-        $query->from('yiitest', 'user')->limit(3)->orderBy(['name.keyword' => SORT_ASC])->indexBy('name')->options(['preference' => '_local']);
+        $query->from('yiitest', 'user')->limit(3)->orderBy(['name' => SORT_ASC])->indexBy('name')->options(['preference' => '_local']);
         //NOTE: preference -> _local has no influence on query result, everything's fine as long as query doesn't fail
 
         $results = [];

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -49,11 +49,11 @@ class QueryTest extends TestCase
         $query = new Query;
         $query->from('yiitest', 'user');
 
-        $query->fields(['name', 'status']);
-        $this->assertEquals(['name', 'status'], $query->fields);
+        $query->storedFields(['name', 'status']);
+        $this->assertEquals(['name', 'status'], $query->storedFields);
 
-        $query->fields('name', 'status');
-        $this->assertEquals(['name', 'status'], $query->fields);
+        $query->storedFields('name', 'status');
+        $this->assertEquals(['name', 'status'], $query->storedFields);
 
         $result = $query->one($this->getConnection());
         $this->assertEquals(2, count($result['fields']));
@@ -61,15 +61,15 @@ class QueryTest extends TestCase
         $this->assertArrayHasKey('name', $result['fields']);
         $this->assertArrayHasKey('_id', $result);
 
-        $query->fields([]);
-        $this->assertEquals([], $query->fields);
+        $query->storedFields([]);
+        $this->assertEquals([], $query->storedFields);
 
         $result = $query->one($this->getConnection());
         $this->assertArrayNotHasKey('fields', $result);
         $this->assertArrayHasKey('_id', $result);
 
-        $query->fields(null);
-        $this->assertNull($query->fields);
+        $query->storedFields(null);
+        $this->assertNull($query->storedFields);
 
         $result = $query->one($this->getConnection());
         $this->assertEquals(3, count($result['_source']));

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -19,6 +19,10 @@ class QueryTest extends TestCase
         if ($command->indexExists('yiitest')) {
             $command->deleteIndex('yiitest');
         }
+        /* FIXME: setup proper mapping for an index?
+         * elasticsearch autocreates field and field.keyword field
+         * for text fields
+         */
 
         $command->insert('yiitest', 'user', ['name' => 'user1', 'email' => 'user1@example.com', 'status' => 1], 1);
         $command->insert('yiitest', 'user', ['name' => 'user2', 'email' => 'user2@example.com', 'status' => 1], 2);
@@ -163,7 +167,7 @@ class QueryTest extends TestCase
         $query = new Query;
         $query->from('yiitest', 'user');
 
-        $result = $query->orderBy(['name' => SORT_ASC])->limit(4)->column('name', $this->getConnection());
+        $result = $query->orderBy(['name.keyword' => SORT_ASC])->limit(4)->column('name', $this->getConnection());
         $this->assertEquals(['user1', 'user2', 'user3', 'user4'], $result);
         $result = $query->column('noname', $this->getConnection());
         $this->assertEquals([null, null, null, null], $result);
@@ -308,7 +312,7 @@ class QueryTest extends TestCase
 
         //test each
         $query = new Query;
-        $query->from('yiitest', 'user')->limit(3)->orderBy(['name' => SORT_ASC])->indexBy('name')->options(['preference' => '_local']);
+        $query->from('yiitest', 'user')->limit(3)->orderBy(['name.keyword' => SORT_ASC])->indexBy('name')->options(['preference' => '_local']);
         //NOTE: preference -> _local has no influence on query result, everything's fine as long as query doesn't fail
 
         $result_keys = [];
@@ -326,7 +330,7 @@ class QueryTest extends TestCase
 
         //test batch
         $query = new Query;
-        $query->from('yiitest', 'user')->limit(3)->orderBy(['name' => SORT_ASC])->indexBy('name')->options(['preference' => '_local']);
+        $query->from('yiitest', 'user')->limit(3)->orderBy(['name.keyword' => SORT_ASC])->indexBy('name')->options(['preference' => '_local']);
         //NOTE: preference -> _local has no influence on query result, everything's fine as long as query doesn't fail
 
         $results = [];

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -19,12 +19,13 @@ class QueryTest extends TestCase
         if ($command->indexExists('yiitest')) {
             $command->deleteIndex('yiitest');
         }
+        $command->createIndex('yiitest');
 
         $command->setMapping('yiitest', 'user', [
             'properties' => [
                 'name' => [ 'type' => 'keyword', 'store' => true ],
                 'email' => [ 'type' => 'keyword', 'store' => true ],
-                'status' => [ 'type' => 'integer' ],
+                'status' => [ 'type' => 'integer', 'store' => true ],
             ],
         ]);
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -181,6 +181,26 @@ class QueryTest extends TestCase
 
     }
 
+    public function testAndWhere() {
+        $query = new Query;
+        $query->where(1)
+            ->andWhere(2)
+            ->andWhere(3);
+
+        $expected = [ 'and', 1, 2, 3 ];
+        $this->assertEquals($expected, $query->where);
+    }
+
+    public function testOrWhere() {
+        $query = new Query;
+        $query->where(1)
+            ->orWhere(2)
+            ->orWhere(3);
+
+        $expected = [ 'or', 1, 2, 3 ];
+        $this->assertEquals($expected, $query->where);
+    }
+
     public function testFilterWhere()
     {
         // should work with hash format

--- a/tests/data/ar/Animal.php
+++ b/tests/data/ar/Animal.php
@@ -40,7 +40,6 @@ class Animal extends ActiveRecord
      */
     public static function setUpMapping($command)
     {
-        $command->deleteMapping(static::index(), static::type());
         $command->setMapping(static::index(), static::type(), [
             static::type() => [
                 "properties" => [

--- a/tests/data/ar/Animal.php
+++ b/tests/data/ar/Animal.php
@@ -43,7 +43,6 @@ class Animal extends ActiveRecord
         $command->deleteMapping(static::index(), static::type());
         $command->setMapping(static::index(), static::type(), [
             static::type() => [
-                "_id" => ["path" => "id", "index" => "not_analyzed", "store" => "yes"],
                 "properties" => [
                     "type" => ["type" => "string", "index" => "not_analyzed"]
                 ]

--- a/tests/data/ar/Customer.php
+++ b/tests/data/ar/Customer.php
@@ -38,12 +38,16 @@ class Customer extends ActiveRecord
 
     public function getExpensiveOrders()
     {
-        return $this->hasMany(Order::className(), ['customer_id' => 'id'])->filter(['range' => ['total' => ['gte' => 50]]])->orderBy('id');
+        return $this->hasMany(Order::className(), ['customer_id' => 'id'])
+            ->where([ 'gte', 'total', 50 ])
+            ->orderBy('id');
     }
 
     public function getExpensiveOrdersWithNullFK()
     {
-        return $this->hasMany(OrderWithNullFK::className(), ['customer_id' => 'id'])->filter(['range' => ['total' => ['gte' => 50]]])->orderBy('id');
+        return $this->hasMany(OrderWithNullFK::className(), ['customer_id' => 'id'])
+            ->where([ 'gte', 'total', 50 ])
+            ->orderBy('id');
     }
 
     public function getOrdersWithNullFK()

--- a/tests/data/ar/Customer.php
+++ b/tests/data/ar/Customer.php
@@ -73,7 +73,6 @@ class Customer extends ActiveRecord
         $command->deleteMapping(static::index(), static::type());
         $command->setMapping(static::index(), static::type(), [
             static::type() => [
-                "_id" => ["path" => "id", "index" => "not_analyzed", "store" => "yes"],
                 "properties" => [
                     "name" =>        ["type" => "string", "index" => "not_analyzed"],
                     "email" =>       ["type" => "string", "index" => "not_analyzed"],

--- a/tests/data/ar/Customer.php
+++ b/tests/data/ar/Customer.php
@@ -78,8 +78,8 @@ class Customer extends ActiveRecord
         $command->setMapping(static::index(), static::type(), [
             static::type() => [
                 "properties" => [
-                    "name" =>        ["type" => "string", "index" => "not_analyzed"],
-                    "email" =>       ["type" => "string", "index" => "not_analyzed"],
+                    "name" =>        ["type" => "string", "index" => "not_analyzed", "store" => true],
+                    "email" =>       ["type" => "string", "index" => "not_analyzed" ],
                     "address" =>     ["type" => "string", "index" => "analyzed"],
                     "status" => $statusIsBoolean ? ["type" => "boolean"] : ["type" => "integer"],
                 ]

--- a/tests/data/ar/Customer.php
+++ b/tests/data/ar/Customer.php
@@ -72,17 +72,15 @@ class Customer extends ActiveRecord
      * @param Command $command
      * @param boolean $statusIsBoolean
      */
-    public static function setUpMapping($command, $statusIsBoolean = false)
+    public static function setUpMapping($command)
     {
-        $command->deleteMapping(static::index(), static::type());
         $command->setMapping(static::index(), static::type(), [
-            static::type() => [
-                "properties" => [
-                    "name" =>        ["type" => "string", "index" => "not_analyzed", "store" => true],
-                    "email" =>       ["type" => "string", "index" => "not_analyzed" ],
-                    "address" =>     ["type" => "string", "index" => "analyzed"],
-                    "status" => $statusIsBoolean ? ["type" => "boolean"] : ["type" => "integer"],
-                ]
+            "properties" => [
+                "id" => ["type"=>"integer", "store" => true],
+                "name" => ["type" => "keyword", "index" => "not_analyzed", "store" => true],
+                "email" => ["type" => "keyword", "index" => "not_analyzed", "store" => true],
+                "address" => ["type" => "text", "index" => "analyzed"],
+                "status" => ["type" => "integer", "store" => true],
             ]
         ]);
 

--- a/tests/data/ar/Item.php
+++ b/tests/data/ar/Item.php
@@ -32,7 +32,6 @@ class Item extends ActiveRecord
         $command->deleteMapping(static::index(), static::type());
         $command->setMapping(static::index(), static::type(), [
             static::type() => [
-                "_id" => ["path" => "id", "index" => "not_analyzed", "store" => "yes"],
                 "properties" => [
                     "name" =>        ["type" => "string", "index" => "not_analyzed"],
                     "category_id" =>      ["type" => "integer"],

--- a/tests/data/ar/Item.php
+++ b/tests/data/ar/Item.php
@@ -29,11 +29,10 @@ class Item extends ActiveRecord
      */
     public static function setUpMapping($command)
     {
-        $command->deleteMapping(static::index(), static::type());
         $command->setMapping(static::index(), static::type(), [
             static::type() => [
                 "properties" => [
-                    "name" =>        ["type" => "string", "index" => "not_analyzed"],
+                    "name" =>        ["type" => "keyword", "index" => "not_analyzed", "store" => true],
                     "category_id" =>      ["type" => "integer"],
                 ]
             ]

--- a/tests/data/ar/Order.php
+++ b/tests/data/ar/Order.php
@@ -114,7 +114,6 @@ class Order extends ActiveRecord
         $command->deleteMapping(static::index(), static::type());
         $command->setMapping(static::index(), static::type(), [
             static::type() => [
-                "_id" => ["path" => "id", "index" => "not_analyzed", "store" => "yes"],
                 "properties" => [
                     "customer_id" => ["type" => "integer"],
 //					"created_at" => ["type" => "string", "index" => "not_analyzed"],

--- a/tests/data/ar/Order.php
+++ b/tests/data/ar/Order.php
@@ -111,7 +111,6 @@ class Order extends ActiveRecord
      */
     public static function setUpMapping($command)
     {
-        $command->deleteMapping(static::index(), static::type());
         $command->setMapping(static::index(), static::type(), [
             static::type() => [
                 "properties" => [

--- a/tests/data/ar/OrderItem.php
+++ b/tests/data/ar/OrderItem.php
@@ -37,7 +37,6 @@ class OrderItem extends ActiveRecord
      */
     public static function setUpMapping($command)
     {
-        $command->deleteMapping(static::index(), static::type());
         $command->setMapping(static::index(), static::type(), [
             static::type() => [
                 "properties" => [

--- a/tests/data/config.php
+++ b/tests/data/config.php
@@ -13,6 +13,7 @@
 
 $config = [
     'elasticsearch' => [
+        'autodetectCluster' => false,
         'nodes' => [
             ['http_address' => 'inet[/127.0.0.1:9200]'],
         ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes/no
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | #112

Notes:
- removed Query::filter()
- queries can be set through either `Query::query()` or through `Query::where()`
- rewrite `QueryBuilder` condition building to support Elasticsearch 5.0. All the where params are wrapped into `constant_score` query
- optimized `Query::andWhere()` and `Query::orWhere()` so it won't generate unnecessary subqueries on subsequent calls.
- remove `Query::fields()` (fields query part is removed in favor of stored_fields and works differently in 5.0)
- add `Query::storedFields()`, `Query::scriptFields()`
- reset`CURL_POSTFIELDS` in `Connection::resetCurlHandle()`, it was causing test errors in 5.4 (because in some cases requests with body and subsequent requests without it were not cleared)
- remove `Command::deleteMapping` because mapping deletion is no longer supported in Elasticsearch 5.0. You can only delete and recreate full index.

It breaks BC with previous version of extension. So I don't know, maybe there has to be two different versions of extension for different elasticsearch versions or it has to be refactor in some way to support running both Elasticsearch >=5.0 and <5.0 by switch 