### PR TITLE
Allow for explain to be set on a query

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -194,6 +194,7 @@ class ActiveRecord extends BaseActiveRecord
 
     /**
      * @return array|null An explanation for each hit on how its score was computed
+     * @since 2.0.5
      */
     public function getExplanation()
     {

--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -58,7 +58,7 @@ class ActiveRecord extends BaseActiveRecord
     private $_score;
     private $_version;
     private $_highlight;
-
+    private $_explanation;
 
     /**
      * Returns the database connection used by this AR class.
@@ -190,6 +190,14 @@ class ActiveRecord extends BaseActiveRecord
     public function getHighlight()
     {
         return $this->_highlight;
+    }
+
+    /**
+     * @return array|null An explanation for each hit on how its score was computed
+     */
+    public function getExplanation()
+    {
+        return $this->_explanation;
     }
 
     /**
@@ -341,6 +349,7 @@ class ActiveRecord extends BaseActiveRecord
         $record->_highlight = isset($row['highlight']) ? $row['highlight'] : null;
         $record->_score = isset($row['_score']) ? $row['_score'] : null;
         $record->_version = isset($row['_version']) ? $row['_version'] : null; // TODO version should always be available...
+        $record->_explanation = isset($row['_explanation']) ? $row['_explanation'] : null;
     }
 
     /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Yii Framework 2 elasticsearch extension Change Log
 - Enh #82: Support HTTPS protocol (dor-denis, beowulfenator)
 - Enh #43: Elasticsearch log target (trntv, beowulfenator)
 - Bug: Added accessor method for the default elasticsearch primary key (kyle-mccarthy)
+- Enh: Added support for explanation on query (kyle-mccarthy) 
 
 
 2.0.4 March 17, 2016

--- a/Query.php
+++ b/Query.php
@@ -171,6 +171,11 @@ class Query extends Component implements QueryInterface
      * @since 2.0.4
      */
     public $options = [];
+    /**
+     * @var Enables explanation for each hit on how its score was computed.
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-explain.html
+     */
+    public $explain;
 
 
     /**
@@ -686,6 +691,18 @@ class Query extends Component implements QueryInterface
     public function postFilter($filter)
     {
         $this->postFilter = $filter;
+        return $this;
+    }
+
+    /**
+     * Explain for how the score of each document was computer
+     * @param $explain
+     * @return $this
+     * @see $explain
+     */
+    public function explain($explain)
+    {
+        $this->explain = $explain;
         return $this;
     }
 }

--- a/Query.php
+++ b/Query.php
@@ -174,6 +174,7 @@ class Query extends Component implements QueryInterface
     /**
      * @var Enables explanation for each hit on how its score was computed.
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-explain.html
+     * @since 2.0.5
      */
     public $explain;
 
@@ -699,6 +700,7 @@ class Query extends Component implements QueryInterface
      * @param $explain
      * @return $this
      * @see $explain
+     * @since 2.0.5
      */
     public function explain($explain)
     {

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -77,6 +77,9 @@ class QueryBuilder extends \yii\base\Object
         if (isset($query->minScore)) {
             $parts['min_score'] = (float)$query->minScore;
         }
+        if (isset($query->explain)) {
+            $parts['explain'] = $query->explain;
+        }
 
         if (empty($query->query)) {
             $parts['query'] = ["match_all" => (object)[]];

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -370,4 +370,30 @@ class QueryTest extends TestCase
         $result = $query->search($this->getConnection());
         $this->assertEquals(3, $result['hits']['total']);
     }
+
+    /**
+     * @group explain
+     * @since 2.0.5
+     */
+    public function testExplain()
+    {
+        $query = new Query();
+        $query->from('yiitest', 'user');
+        $query->explain(true);
+        $result = $query->search($this->getConnection());
+        $this->assertTrue(is_array($result['hits']['hits'][0]['_explanation']));
+        $this->assertTrue(array_key_exists('_explanation', $result['hits']['hits'][0]));
+    }
+
+    /**
+     * @group explain
+     * @since 2.0.5
+     */
+    public function testNoExplain()
+    {
+        $query = new Query();
+        $query->from('yiitest', 'user');
+        $result = $query->search($this->getConnection());
+        $this->assertFalse(array_key_exists('_explanation', $result['hits']['hits'][0]));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | n/a

Allow for explain to be set on a query, so you can see how the score for a certain document is calculated.

https://www.elastic.co/guide/en/elasticsearch/reference/current/search-explain.html

Can be used by `ElasticActiveRecord::find()->query(...)->explain(true)->all();`.
