### PR TITLE
2.1

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -510,6 +510,8 @@ class Connection extends Component
             CURLOPT_WRITEFUNCTION => null,
             CURLOPT_READFUNCTION => null,
             CURLOPT_PROGRESSFUNCTION => null,
+            CURLOPT_POST => false,
+            CURLOPT_POSTFIELDS => null,
         ];
         curl_setopt_array($this->_curl, $unsetValues);
         if (function_exists('curl_reset')) { // since PHP 5.5.0

--- a/Connection.php
+++ b/Connection.php
@@ -424,7 +424,10 @@ class Connection extends Component
             CURLOPT_RETURNTRANSFER => false,
             CURLOPT_HEADER         => false,
             // http://www.php.net/manual/en/function.curl-setopt.php#82418
-            CURLOPT_HTTPHEADER     => ['Expect:'],
+            CURLOPT_HTTPHEADER     => [
+                'Expect:',
+                'Content-Type: application/json',
+            ],
 
             CURLOPT_WRITEFUNCTION  => function ($curl, $data) use (&$body) {
                 $body .= $data;

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -185,6 +185,14 @@ class QueryBuilder extends \yii\base\Object
             'not like' => 'buildLikeCondition',
             'or like' => 'buildLikeCondition',
             'or not like' => 'buildLikeCondition',
+			'lt' => 'buildUnboundRangeCondition',
+			'<' => 'buildUnboundRangeCondition',
+			'lte' => 'buildUnboundRangeCondition',
+			'<=' => 'buildUnboundRangeCondition',
+			'gt' => 'buildUnboundRangeCondition',
+			'>' => 'buildUnboundRangeCondition',
+			'gte' => 'buildUnboundRangeCondition',
+			'>=' => 'buildUnboundRangeCondition',
         ];
 
         if (empty($condition)) {
@@ -338,6 +346,40 @@ class QueryBuilder extends \yii\base\Object
         }
 
         return $filter;
+    }
+
+    private function buildUnboundRangeCondition($operator, $operands)
+    {
+    	if (!isset($operands[0], $operands[1])) {
+    		throw new InvalidParamException("Operator '$operator' requires two operands.");
+    	}
+
+    	list($column, $value) = $operands;
+    	if ($column == '_id') {
+    		$column = '_uid';
+    	}
+
+    	$range_operator = 'gte';
+
+    	if (in_array($operator, ['gte', '>='])) {
+    		$range_operator = 'gte';
+    	} else if (in_array($operator, ['lte', '<='])) {
+    		$range_operator = 'lte';
+    	} else if (in_array($operator, ['gt', '>'])) {
+    		$range_operator = 'gt';
+    	} else if (in_array($operator, ['lt', '<'])) {
+    		$range_operator = 'lt';
+    	}
+
+    	$filter = [
+    		'range' => [
+    			"$column" => [
+    				"$range_operator" => $value
+    			]
+    		]
+    	];
+
+    	return $filter;
     }
 
     protected function buildCompositeInCondition($operator, $columns, $values)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | 
| Tests pass?   | 
| Fixed issues  |

In Elasticsearch 5.x, the "Contect-Type" header is kinda required. If it isn't provided, it will display a warning in the deprecation.log file. This fix assumes that the request is always in JSON format. Not quite sure if there is another format besides JSON when sending a request to Elasticsearch.