### PR TITLE
since elasticsearch 6, content type is mandatory

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -423,7 +423,7 @@ class Connection extends Component
             CURLOPT_RETURNTRANSFER => false,
             CURLOPT_HEADER         => false,
             // http://www.php.net/manual/en/function.curl-setopt.php#82418
-            CURLOPT_HTTPHEADER     => ['Expect:'],
+            CURLOPT_HTTPHEADER     => ['Expect:', 'Content-Type: application/json'],
 
             CURLOPT_WRITEFUNCTION  => function ($curl, $data) use (&$body) {
                 $body .= $data;


### PR DESCRIPTION
since elasticsearch 6, content type is mandatory. Otherwise, requests will all fail.

https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
