### PR TITLE
added Suggestions to ActiveDataProvider

### DIFF
--- a/ActiveDataProvider.php
+++ b/ActiveDataProvider.php
@@ -53,6 +53,30 @@ class ActiveDataProvider extends \yii\data\ActiveDataProvider
     }
 
     /**
+     * @return array all suggestion results
+     */
+    public function getSuggestions()
+    {
+        $results = $this->getQueryResults();
+        return isset($results['suggest']) ? $results['suggest'] : [];
+    }
+
+    /**
+     * Returns results of the specified suggestion.
+     * @param string $name suggestion name.
+     * @return array suggestion results.
+     * @throws InvalidCallException if requested suggestion is not present in query results.
+     */
+    public function getSuggestion($name)
+    {
+        $suggestions = $this->getSuggestions();
+        if (!isset($suggestions[$name])) {
+            throw new InvalidCallException("Suggestion '{$name}' is not present.");
+        }
+        return $suggestions[$name];
+    }
+
+    /**
      * @return array all aggregations results
      */
     public function getAggregations()

--- a/docs/guide/usage-data-providers.md
+++ b/docs/guide/usage-data-providers.md
@@ -53,3 +53,28 @@ $models = $provider->getModels();
 $aggregations = $provider->getAggregations();
 $fooAggregation = $provider->getAggregation('foo');
 ```
+
+You can also fetch the results of a Suggestion similarly:
+
+```php
+use yii\elasticsearch\ActiveDataProvider;
+use yii\elasticsearch\Query;
+
+$query = new Query();
+$query->from('yiitest', 'user')
+    ->addSuggestion('foo', [
+        'text' => 'yii2',
+        'term' => [
+            'field' => 'bar'
+        ]
+    ]);
+$provider = new ActiveDataProvider([
+    'query' => $query,
+    'pagination' => [
+        'pageSize' => 10,
+    ]
+]);
+$models = $provider->getModels();
+$suggestions = $provider->getSuggestions();
+$fooSuggestion = $provider->getSuggestion('foo');
+```


### PR DESCRIPTION
Since Elasticsearch 5.0.0 it should be preferred to use the suggestion functionality via the _search endpoint rather than the _suggest endpoint. This pull request makes it possible to retrieve such results, similar to the Aggregations retrieval.



https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | no (bower.json missing?)
| Fixed issues  | #156

