### PR TITLE
using _delete_by_query insted depricated _query

### DIFF
--- a/Command.php
+++ b/Command.php
@@ -89,9 +89,9 @@ class Command extends Component
         if ($this->type !== null) {
             $url[] = $this->type;
         }
-        $url[] = '_query';
+        $url[] = '_delete_by_query';
 
-        return $this->db->delete($url, array_merge($this->options, $options), $query);
+        return $this->db->post($url, array_merge($this->options, $options), $query);
     }
 
     /**


### PR DESCRIPTION
Since es 1.5.3 deleting document by query [was depricated](https://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html), in 2.0 was removed.
In v5.0 we should use [DeleteByQuery API](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/docs-delete-by-query.html) insted.
Otherwise we must have [delete_by_query plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/2.0/plugins-delete-by-query.html) installed.