### PR TITLE
fix data types in docs from string to text

### DIFF
--- a/docs/guide-ja/mapping-indexing.md
+++ b/docs/guide-ja/mapping-indexing.md
@@ -21,9 +21,9 @@ Class Book extends yii\elasticsearch\ActiveRecord
         return [
             static::type() => [
                 'properties' => [
-                    'name'           => ['type' => 'string'],
-                    'author_name'    => ['type' => 'string'],
-                    'publisher_name' => ['type' => 'string'],
+                    'name'           => ['type' => 'text'],
+                    'author_name'    => ['type' => 'text'],
+                    'publisher_name' => ['type' => 'text'],
                     'created_at'     => ['type' => 'long'],
                     'updated_at'     => ['type' => 'long'],
                     'status'         => ['type' => 'long'],

--- a/docs/guide/mapping-indexing.md
+++ b/docs/guide/mapping-indexing.md
@@ -19,9 +19,9 @@ Class Book extends yii\elasticsearch\ActiveRecord
         return [
             static::type() => [
                 'properties' => [
-                    'name'           => ['type' => 'string'],
-                    'author_name'    => ['type' => 'string'],
-                    'publisher_name' => ['type' => 'string'],
+                    'name'           => ['type' => 'text'],
+                    'author_name'    => ['type' => 'text'],
+                    'publisher_name' => ['type' => 'text'],
                     'created_at'     => ['type' => 'long'],
                     'updated_at'     => ['type' => 'long'],
                     'status'         => ['type' => 'long'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | -
| Fixed issues  | none

Since 5-th version of ElasticSearch [new data types is used](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html). In particular `text` or `keyword` type should be used instead of `string` type.
But on docs from 2.1 branch still used old data types.
