### PR TITLE
Fix code example in documentaion of using fuzziness

### DIFF
--- a/docs/guide-fr/usage-ar.md
+++ b/docs/guide-fr/usage-ar.md
@@ -86,12 +86,14 @@ $customers = Customer::find()->active()->all(); // récupère l'ensemble des doc
 // http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
 $result = Article::find()->query(["match" => ["title" => "yii"]])->all(); // articles dont le titre contient "yii"
 
-// http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-flt-query.html
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html#query-dsl-match-query-fuzziness
 $query = Article::find()->query([
-    "fuzzy_like_this" => [
-        "fields" => ["title", "description"],
-        "like_text" => "Cette requête retournera les articles similaires à ce texte :-)",
-        "max_query_terms" => 12
+    'match' => [
+        'title' => [
+            'query' => 'This query will return articles that are similar to this text :-)',
+            'operator' => 'and',
+            'fuzziness' => 'AUTO'
+        ]
     ]
 ]);
 

--- a/docs/guide-fr/usage-ar.md
+++ b/docs/guide-fr/usage-ar.md
@@ -90,7 +90,7 @@ $result = Article::find()->query(["match" => ["title" => "yii"]])->all(); // art
 $query = Article::find()->query([
     'match' => [
         'title' => [
-            'query' => 'This query will return articles that are similar to this text :-)',
+            'query' => 'Cette requête retournera les articles similaires à ce texte :-)',
             'operator' => 'and',
             'fuzziness' => 'AUTO'
         ]

--- a/docs/guide-ja/usage-ar.md
+++ b/docs/guide-ja/usage-ar.md
@@ -85,12 +85,14 @@ $customers = Customer::find()->active()->all(); // クエリによって全て�
 // http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
 $result = Article::find()->query(["match" => ["title" => "yii"]])->all(); // articles whose title contains "yii"
 
-// http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-flt-query.html
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html#query-dsl-match-query-fuzziness
 $query = Article::find()->query([
-    "fuzzy_like_this" => [
-        "fields" => ["title", "description"],
-        "like_text" => "このクエリは、このテキストに似た記事を返します :-)",
-        "max_query_terms" => 12
+    'match' => [
+        'title' => [
+            'query' => 'This query will return articles that are similar to this text :-)',
+            'operator' => 'and',
+            'fuzziness' => 'AUTO'
+        ]
     ]
 ]);
 

--- a/docs/guide-ja/usage-ar.md
+++ b/docs/guide-ja/usage-ar.md
@@ -89,7 +89,7 @@ $result = Article::find()->query(["match" => ["title" => "yii"]])->all(); // art
 $query = Article::find()->query([
     'match' => [
         'title' => [
-            'query' => 'This query will return articles that are similar to this text :-)',
+            'query' => 'このクエリは、このテキストに似た記事を返します :-)',
             'operator' => 'and',
             'fuzziness' => 'AUTO'
         ]

--- a/docs/guide/usage-ar.md
+++ b/docs/guide/usage-ar.md
@@ -92,12 +92,14 @@ $customers = Customer::find()->active()->all(); // find all by query (using the 
 // http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
 $result = Article::find()->query(["match" => ["title" => "yii"]])->all(); // articles whose title contains "yii"
 
-// http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-flt-query.html
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html#query-dsl-match-query-fuzziness
 $query = Article::find()->query([
-    "fuzzy_like_this" => [
-        "fields" => ["title", "description"],
-        "like_text" => "This query will return articles that are similar to this text :-)",
-        "max_query_terms" => 12
+    'match' => [
+        'title' => [
+            'query' => 'This query will return articles that are similar to this text :-)',
+            'operator' => 'and',
+            'fuzziness' => 'AUTO'
+        ]
     ]
 ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | -
| Fixed issues  | -

Since 5th version of Elasticsearch the `fuzzy_like_this` query has been removed. Take a look [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-flt-query.html).
Now we should use `fuzziness` parameter for `match` query.
