### PR TITLE
Update ActiveQuery::column()

### DIFF
--- a/ActiveQuery.php
+++ b/ActiveQuery.php
@@ -319,7 +319,6 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     {
         if ($field === '_id') {
             $command = $this->createCommand($db);
-            $command->queryParts['fields'] = [];
             $command->queryParts['_source'] = false;
             $result = $command->search();
             if ($result === false) {


### PR DESCRIPTION
It seems that setting the fields param to an empty array when the code asks for the '_id' field, causes a parsing exception with reason: "Unknown key for a START_ARRAY in [fields]."

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | ?
| Fixed issues  | 
