### PR TITLE
Fix ActiveQuery::column exception, when selecting _id

### DIFF
--- a/ActiveQuery.php
+++ b/ActiveQuery.php
@@ -319,7 +319,6 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     {
         if ($field === '_id') {
             $command = $this->createCommand($db);
-            $command->queryParts['fields'] = [];
             $command->queryParts['_source'] = false;
             $result = $command->search();
             if ($result === false) {

--- a/tests/ActiveQueryTest.php
+++ b/tests/ActiveQueryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace yiiunit\extensions\elasticsearch;
+use yiiunit\extensions\elasticsearch\data\ar\Item;
+
+
+/**
+ * @group elasticsearch
+ */
+class ActiveQueryTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $command = $this->getConnection()->createCommand();
+
+        // delete index
+        if ($command->indexExists(Item::index())) {
+            $command->deleteIndex(Item::index());
+        }
+        Item::setUpMapping($command);
+
+        $command->insert(Item::index(), Item::type(), ['name' => 'item1', 'category_id' => 'category1'], 1);
+
+        $command->flushIndex();
+    }
+
+    /**
+     * @throws \yii\elasticsearch\Exception
+     */
+    public function testColumn()
+    {
+        $activeQuery = Item::find()->where(['name' => 'item1'])->asArray();
+
+        $result = $activeQuery->column('category_id', $this->getConnection());
+        $this->assertEquals(['category1'], $result);
+        $result = $activeQuery->column('_id', $this->getConnection());
+        $this->assertEquals([1], $result);
+        $result = $activeQuery->column('noname', $this->getConnection());
+        $this->assertEquals([null], $result);
+        $result = $activeQuery->scalar('name', $this->getConnection());
+        $this->assertEquals('item1', $result);
+    }
+}


### PR DESCRIPTION
@cebe This replaces https://github.com/yiisoft/yii2-elasticsearch/pull/189

To solve: setting the fields param to an empty array when the code asks for the '_id' field, causes a parsing exception with reason: "Unknown key for a START_ARRAY in [fields]."

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | ?
| Fixed issues  | ?
