### PR TITLE
Added check to ActiveRecord::insert() to validate if insert was indeed successful

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -467,6 +467,10 @@ class ActiveRecord extends BaseActiveRecord
             $this->getPrimaryKey(),
             $options
         );
+        
+        if ($response === false) {
+            return false;
+        }
 
         $pk = static::primaryKey()[0];
         $this->$pk = $response['_id'];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 elasticsearch extension Change Log
 -----------------------
 
 - Bug #180: Fixed `count()` compatibility with PHP 7.2 to not call it on scalar values (cebe)
+- Bug #199: Fixed `ActiveRecord::insert()` check if insert was indeed successful (rhertogh)
 
 
 2.0.5 March 20, 2018


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

According to the `insert` function description in step 4 it should "insert the record into database. If this fails, it will skip the rest of the steps;" but currently there is no check to validate if the insert was indeed successful and the function always returns `true` even though no document was created.