### PR TITLE
Bugfix: Fixed "Bad Request" on "run query" in debug panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 elasticsearch extension Change Log
 -----------------------
 
 - Bug #180: Fixed `count()` compatibility with PHP 7.2 to not call it on scalar values (cebe)
+- Bug #227: Fixed `Bad Request (#400): Unable to verify your data submission.` in debug details panel 'run query'
 
 
 2.0.5 March 20, 2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 elasticsearch extension Change Log
 -----------------------
 
 - Bug #180: Fixed `count()` compatibility with PHP 7.2 to not call it on scalar values (cebe)
-- Bug #227: Fixed `Bad Request (#400): Unable to verify your data submission.` in debug details panel 'run query'
+- Bug #227: Fixed `Bad Request (#400): Unable to verify your data submission.` in debug details panel 'run query' (rhertogh)
 
 
 2.0.5 March 20, 2018

--- a/DebugPanel.php
+++ b/DebugPanel.php
@@ -71,6 +71,9 @@ EOD;
      */
     public function getDetail()
     {
+        //Register YiiAsset in order to inject csrf token in ajax requests
+        YiiAsset::register(\Yii::$app->view);
+        
         $timings = $this->calculateTimings();
         ArrayHelper::multisort($timings, 3, SORT_DESC);
         $rows = [];


### PR DESCRIPTION
This pr fixes the "Bad Request (#400): Unable to verify your data submission." error when using the "run query" action in the debugger details panel by registering the YiiAsset in order to inject csrf token in ajax requests

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

![image](https://user-images.githubusercontent.com/1292337/56979209-851d1000-6b79-11e9-9acf-45d867960719.png)

