### PR TITLE
fix(prepareTotalCount): infinite loop

### DIFF
--- a/ActiveDataProvider.php
+++ b/ActiveDataProvider.php
@@ -116,7 +116,7 @@ class ActiveDataProvider extends \yii\data\ActiveDataProvider
         }
 
         if (is_array($this->_queryResults)) {
-            return isset($results['hits']['total']) ? (int) $results['hits']['total'] : 0;
+            return isset($this->_queryResults['hits']['total']) ? (int) $this->_queryResults['hits']['total'] : 0;
         }
 
         $query = clone $this->query;

--- a/ActiveDataProvider.php
+++ b/ActiveDataProvider.php
@@ -115,8 +115,12 @@ class ActiveDataProvider extends \yii\data\ActiveDataProvider
             throw new InvalidConfigException('The "query" property must be an instance "' . Query::className() . '" or its subclasses.');
         }
 
-        $results = $this->getQueryResults();
-        return isset($results['hits']['total']) ? (int)$results['hits']['total'] : 0;
+        if (is_array($this->_queryResults)) {
+            return isset($results['hits']['total']) ? (int) $results['hits']['total'] : 0;
+        }
+
+        $query = clone $this->query;
+        return (int) $query->limit(-1)->offset(-1)->orderBy([])->count('*', $this->db);
     }
 
     /**


### PR DESCRIPTION
related to #134 and #201.

There is currently an infinite loop that happens when following method is called before getting any results from ElasticSearch:

```
prepareModels()
->getPagination()
->prepareTotalCount()
->getQueryResults()
->prepare()
->prepareModels()
```

It seems the infinite loop issue has already been fixed at some point, but then reverted by https://github.com/yiisoft/yii2-elasticsearch/commit/58466a83a86f3af3ad80949427592f4e55ff3c81.

This PR tries a different fix to the same issue by simply ensuring `prepareTotalCount()` to request the number from database in case there is no available query response, the exact same way it was done with core `ActiveDataProvider::prepareTotalCount()` for SQL databases, Mongo and Sphinx extensions.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | (good question)
| Fixed issues  | #134,#201
