### PR TITLE
change mapping-indexing example

### DIFF
--- a/docs/guide-ja/mapping-indexing.md
+++ b/docs/guide-ja/mapping-indexing.md
@@ -17,16 +17,14 @@ Class Book extends yii\elasticsearch\ActiveRecord
     public static function mapping()
     {
         return [
-            static::type() => [
-                'properties' => [
-                    'name'           => ['type' => 'text'],
-                    'author_name'    => ['type' => 'text'],
-                    'publisher_name' => ['type' => 'text'],
-                    'created_at'     => ['type' => 'long'],
-                    'updated_at'     => ['type' => 'long'],
-                    'status'         => ['type' => 'long'],
-                ]
-            ],
+            'properties' => [
+                'name'           => ['type' => 'text'],
+                'author_name'    => ['type' => 'text'],
+                'publisher_name' => ['type' => 'text'],
+                'created_at'     => ['type' => 'long'],
+                'updated_at'     => ['type' => 'long'],
+                'status'         => ['type' => 'long'],
+            ]
         ];
     }
 

--- a/docs/guide-ru/mapping-indexing.md
+++ b/docs/guide-ru/mapping-indexing.md
@@ -17,15 +17,13 @@ class Book extends yii\elasticsearch\ActiveRecord
     public static function mapping()
     {
         return [
-            static::type() => [
-                'properties' => [
-                    'name'           => ['type' => 'string'],
-                    'author_name'    => ['type' => 'string'],
-                    'publisher_name' => ['type' => 'string'],
-                    'created_at'     => ['type' => 'long'],
-                    'updated_at'     => ['type' => 'long'],
-                    'status'         => ['type' => 'long'],
-                ]
+            'properties' => [
+                'name'           => ['type' => 'string'],
+                'author_name'    => ['type' => 'string'],
+                'publisher_name' => ['type' => 'string'],
+                'created_at'     => ['type' => 'long'],
+                'updated_at'     => ['type' => 'long'],
+                'status'         => ['type' => 'long'],
             ],
         ];
     }

--- a/docs/guide/mapping-indexing.md
+++ b/docs/guide/mapping-indexing.md
@@ -17,16 +17,14 @@ class Book extends yii\elasticsearch\ActiveRecord
     public static function mapping()
     {
         return [
-            static::type() => [
-                'properties' => [
+            'properties' => [
                     'name'           => ['type' => 'text'],
                     'author_name'    => ['type' => 'text'],
                     'publisher_name' => ['type' => 'text'],
                     'created_at'     => ['type' => 'long'],
                     'updated_at'     => ['type' => 'long'],
                     'status'         => ['type' => 'long'],
-                ]
-            ],
+            ]
         ];
     }
 


### PR DESCRIPTION
With the old example i get this error:
Elasticsearch request failed with code 400. Response body:
{"error":{"root_cause":[{"type":"mapper_parsing_exception","reason":"Root mapping definition has unsupported parameters

| Q             | A
| ------------- | ---
| Is bugfix    |  yes
| New feature  | no
| Breaks BC    | no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
