### PR TITLE
 InvalidParamException to InvalidArgumentException

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -11,7 +11,6 @@ use Yii;
 use yii\base\InvalidArgumentException;
 use yii\base\InvalidCallException;
 use yii\base\InvalidConfigException;
-use yii\base\InvalidParamException;
 use yii\base\NotSupportedException;
 use yii\db\BaseActiveRecord;
 use yii\db\StaleObjectException;
@@ -553,7 +552,7 @@ class ActiveRecord extends BaseActiveRecord
 
         if (isset($options['optimistic_locking']) && $options['optimistic_locking']) {
             if ($this->_version === null) {
-                throw new InvalidParamException('Unable to use optimistic locking on a record that has no version set. Refer to the docs of ActiveRecord::update() for details.');
+                throw new InvalidArgumentException('Unable to use optimistic locking on a record that has no version set. Refer to the docs of ActiveRecord::update() for details.');
             }
             $options['version'] = $this->_version;
             unset($options['optimistic_locking']);
@@ -763,7 +762,7 @@ class ActiveRecord extends BaseActiveRecord
         }
         if (isset($options['optimistic_locking']) && $options['optimistic_locking']) {
             if ($this->_version === null) {
-                throw new InvalidParamException('Unable to use optimistic locking on a record that has no version set. Refer to the docs of ActiveRecord::delete() for details.');
+                throw new InvalidArgumentException('Unable to use optimistic locking on a record that has no version set. Refer to the docs of ActiveRecord::delete() for details.');
             }
             $options['version'] = $this->_version;
             unset($options['optimistic_locking']);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Yii Framework 2 elasticsearch extension Change Log
 - Chg: Removed `Command::getIndexStatus()` and added `getIndexStats()` and `getIndexRecoveryStats()` to reflect changes in Elasticsearch 5.0 (cebe)
 - Chg: Search queries that result in a 404 error due to missing indices are now no longer silently interpreted as empty result, but will throw an exception (cebe)
 - Enh #222: Added collapse support (walkskyer)
+- Chg: Replace InvalidParamException with InvalidArgumentException (Julian-B90)
 
 2.0.5 under development
 2.0.6 under development

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Yii Framework 2 elasticsearch extension Change Log
 - Chg: Removed `Command::getIndexStatus()` and added `getIndexStats()` and `getIndexRecoveryStats()` to reflect changes in Elasticsearch 5.0 (cebe)
 - Chg: Search queries that result in a 404 error due to missing indices are now no longer silently interpreted as empty result, but will throw an exception (cebe)
 - Enh #222: Added collapse support (walkskyer)
-- Chg: Replace InvalidParamException with InvalidArgumentException (Julian-B90)
+- Chg #269: Replace InvalidParamException with InvalidArgumentException (Julian-B90)
 
 2.0.5 under development
 2.0.6 under development

--- a/Connection.php
+++ b/Connection.php
@@ -10,7 +10,7 @@ namespace yii\elasticsearch;
 use Yii;
 use yii\base\Component;
 use yii\base\InvalidConfigException;
-use yii\base\InvalidParamException;
+use yii\base\InvalidArgumentException;
 use yii\helpers\Json;
 
 /**
@@ -589,7 +589,7 @@ class Connection extends Component
                 $decoded['error'] = preg_replace('/\b\w+?Exception\[/', "<span style=\"color: red;\">\\0</span>\n               ", $decoded['error']);
             }
             return $decoded;
-        } catch(InvalidParamException $e) {
+        } catch(InvalidArgumentException $e) {
             return $body;
         }
     }

--- a/Query.php
+++ b/Query.php
@@ -9,7 +9,7 @@ namespace yii\elasticsearch;
 
 use Yii;
 use yii\base\Component;
-use yii\base\InvalidParamException;
+use yii\base\InvalidArgumentException;
 use yii\db\QueryInterface;
 use yii\db\QueryTrait;
 
@@ -784,14 +784,14 @@ class Query extends Component implements QueryInterface
      * Sets the options to be passed to the command created by this query.
      * @param array $options the options to be set.
      * @return $this the query object itself
-     * @throws InvalidParamException if $options is not an array
+     * @throws InvalidArgumentException if $options is not an array
      * @see Command::$options
      * @since 2.0.4
      */
     public function options($options)
     {
         if (!is_array($options)) {
-            throw new InvalidParamException('Array parameter expected, ' . gettype($options) . ' received.');
+            throw new InvalidArgumentException('Array parameter expected, ' . gettype($options) . ' received.');
         }
 
         $this->options = $options;
@@ -802,14 +802,14 @@ class Query extends Component implements QueryInterface
      * Adds more options, overwriting existing options.
      * @param array $options the options to be added.
      * @return $this the query object itself
-     * @throws InvalidParamException if $options is not an array
+     * @throws InvalidArgumentException if $options is not an array
      * @see options()
      * @since 2.0.4
      */
     public function addOptions($options)
     {
         if (!is_array($options)) {
-            throw new InvalidParamException('Array parameter expected, ' . gettype($options) . ' received.');
+            throw new InvalidArgumentException('Array parameter expected, ' . gettype($options) . ' received.');
         }
 
         $this->options = array_merge($this->options, $options);

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -8,7 +8,7 @@
 namespace yii\elasticsearch;
 
 use yii\base\BaseObject;
-use yii\base\InvalidParamException;
+use yii\base\InvalidArgumentException;
 use yii\base\NotSupportedException;
 use yii\helpers\Json;
 
@@ -163,7 +163,7 @@ class QueryBuilder extends BaseObject
      * Parses the condition specification and generates the corresponding SQL expression.
      *
      * @param string|array $condition the condition specification. Please refer to [[Query::where()]] on how to specify a condition.
-     * @throws \yii\base\InvalidParamException if unknown operator is used in query
+     * @throws \yii\base\InvalidArgumentException if unknown operator is used in query
      * @throws \yii\base\NotSupportedException if string conditions are used in where
      * @return string the generated SQL expression
      */
@@ -205,7 +205,7 @@ class QueryBuilder extends BaseObject
 
                 return $this->$method($operator, $condition);
             } else {
-                throw new InvalidParamException('Found unknown operator in query: ' . $operator);
+                throw new InvalidArgumentException('Found unknown operator in query: ' . $operator);
             }
         } else { // hash format: 'column1' => 'value1', 'column2' => 'value2', ...
 
@@ -246,7 +246,7 @@ class QueryBuilder extends BaseObject
     private function buildNotCondition($operator, $operands)
     {
         if (count($operands) != 1) {
-            throw new InvalidParamException("Operator '$operator' requires exactly one operand.");
+            throw new InvalidArgumentException("Operator '$operator' requires exactly one operand.");
         }
 
         $operand = reset($operands);
@@ -269,7 +269,7 @@ class QueryBuilder extends BaseObject
         } else if ($operator === 'or') {
             $clause = 'should';
         } else {
-            throw new InvalidParamException("Operator should be 'or' or 'and'");
+            throw new InvalidArgumentException("Operator should be 'or' or 'and'");
         }
 
         foreach ($operands as $operand) {
@@ -294,7 +294,7 @@ class QueryBuilder extends BaseObject
     private function buildBetweenCondition($operator, $operands)
     {
         if (!isset($operands[0], $operands[1], $operands[2])) {
-            throw new InvalidParamException("Operator '$operator' requires three operands.");
+            throw new InvalidArgumentException("Operator '$operator' requires three operands.");
         }
 
         list($column, $value1, $value2) = $operands;
@@ -312,7 +312,7 @@ class QueryBuilder extends BaseObject
     private function buildInCondition($operator, $operands)
     {
         if (!isset($operands[0], $operands[1]) || !is_array($operands)) {
-            throw new InvalidParamException("Operator '$operator' requires array of two operands: column and values");
+            throw new InvalidArgumentException("Operator '$operator' requires array of two operands: column and values");
         }
 
         list($column, $values) = $operands;
@@ -400,7 +400,7 @@ class QueryBuilder extends BaseObject
     private function buildHalfBoundedRangeCondition($operator, $operands)
     {
         if (!isset($operands[0], $operands[1])) {
-            throw new InvalidParamException("Operator '$operator' requires two operands.");
+            throw new InvalidArgumentException("Operator '$operator' requires two operands.");
         }
 
         list($column, $value) = $operands;
@@ -421,7 +421,7 @@ class QueryBuilder extends BaseObject
         }
 
         if ($range_operator === null) {
-            throw new InvalidParamException("Operator '$operator' is not implemented.");
+            throw new InvalidArgumentException("Operator '$operator' is not implemented.");
         }
 
         $filter = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | no
| Fixed issues  | no

InvalidParamException is deprecated since 2.0.14. 
Use `InvalidArgumentException` instead.