### PR TITLE
Fix prepareTotalCount() support ElasticSearch 7.x

### DIFF
--- a/ActiveDataProvider.php
+++ b/ActiveDataProvider.php
@@ -116,7 +116,10 @@ class ActiveDataProvider extends \yii\data\ActiveDataProvider
         }
 
         $results = $this->getQueryResults();
-        return isset($results['hits']['total']) ? (int)$results['hits']['total'] : 0;
+        if (isset($results['hits']['total'])) {
+            return is_array($results['hits']['total']) ? (int)$results['hits']['total']['value'] : (int)$results['hits']['total'];
+        }
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Fix the return value of prepareTotalCount() in ActiveDataProvider to support elasticsearch 7.x

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
