### PR TITLE
make `count()` code in `Query` consistent with `ActiveDataProvider`

### DIFF
--- a/Query.php
+++ b/Query.php
@@ -470,9 +470,12 @@ class Query extends Component implements QueryInterface
         // performing a query with return size of 0, is equal to getting result stats such as count
         // https://www.elastic.co/guide/en/elasticsearch/reference/5.6/breaking_50_search_changes.html#_literal_search_type_literal
         $result = $this->createCommand($db)->search(['size' => 0]);
+
         // since ES7 totals are returned as array (with count and precision values)
-        $count = is_array($result['hits']['total']) ? $result['hits']['total']['value'] : $result['hits']['total'];
-        return $count;
+        if (isset($result['hits']['total'])) {
+            return is_array($result['hits']['total']) ? (int)$result['hits']['total']['value'] : (int)$result['hits']['total'];
+        }
+        return 0;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

