### PR TITLE
For an existing record, delete it twice in a row. Immediately after t…

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -853,7 +853,7 @@ class ActiveRecord extends BaseActiveRecord
         $n = 0;
         $errors = [];
         foreach ($response['items'] as $item) {
-            if (isset($item['delete']['status']) && $item['delete']['status'] == 200) {
+            if (isset($item['delete']['status']) && ($item['delete']['status'] == 200 || $item['delete']['status'] == 404)) {
                 if (isset($item['delete']['found']) && $item['delete']['found']) {
                     # ES5 uses "found"
                     $n++;


### PR DESCRIPTION
For an existing record, delete it twice in a row. Immediately after the first deletion, 404 is returned for the second deletion

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

The code Below will repoer errors  "yii\elasticsearch\ActiveRecord::deleteAll failed deleting records"
```php
  //$this->model is a ActiveRecord instance
        $r1=$this->model->deleteAll(['id'=>1]);
        #sleep(2)
        $r2=$this->model->deleteAll(['id'=>1]);
        var_dump($r1);
        var_dump($r2);
```
Because you can still find the data when you query immediately after deletion

![image](https://user-images.githubusercontent.com/4144760/109392116-4f076d80-7955-11eb-9670-525ccb3b0c2a.png)














