### PR TITLE
Added track_total_hits to Query::count() in order to count more then 10000 documents

### DIFF
--- a/Query.php
+++ b/Query.php
@@ -450,9 +450,10 @@ class Query extends Component implements QueryInterface
         if ($this->emulateExecution) {
             return 0;
         }
-        // performing a query with return size of 0, is equal to getting result stats such as count
+        // performing a query with return size of 0 and track_total_hits enabled, is equal to getting result stats such as count
         // https://www.elastic.co/guide/en/elasticsearch/reference/5.6/breaking_50_search_changes.html#_literal_search_type_literal
-        $result = $this->createCommand($db)->search(['size' => 0]);
+        // https://www.elastic.co/guide/en/elasticsearch/reference/master/search-your-data.html#track-total-hits
+        $result = $this->createCommand($db)->search(['size' => 0, 'track_total_hits' => 'true']);
 
         // since ES7 totals are returned as array (with count and precision values)
         if (isset($result['hits']['total'])) {


### PR DESCRIPTION
By default ElasticSearch returns 10000 hits (https://www.elastic.co/guide/en/elasticsearch/reference/master/search-your-data.html#track-total-hits)
All hits can be returned by setting track_total_hits to true

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -
