### PR TITLE
Fixed Query::source() when $source = `false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Elasticsearch extension Change Log
 2.1.1 under development
 -----------------------
 
-- no changes in this release.
+- Bug #298: Fixed ElasticSearch performance when passing `false` to `Query::source()` (rhertogh)
 
 
 2.1.0 July 21, 2020

--- a/Query.php
+++ b/Query.php
@@ -724,13 +724,13 @@ class Query extends Component implements QueryInterface
     /**
      * Sets the source filtering, specifying how the `_source` field of the
      * document should be returned.
-     * @param array $source the source patterns to be selected.
+     * @param array|string|null|false $source the source patterns to be selected.
      * @return $this the query object itself
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-source-filtering.html
      */
     public function source($source)
     {
-        if (is_array($source) || $source === null) {
+        if (is_array($source) || $source === null  || $source === false) {
             $this->source = $source;
         } else {
             $this->source = func_get_args();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

The source field can be set to `false` in which case no source will be returned (https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#source-filtering).

Before this fix when passing `false` to the `source` function it would be passed as an array (`[false]` by Yii to ElasticSearch. This would cause ElasticSearch to treat it as field which it tries to match. Since there is often no field called 'false' no source is returned. Therefore it might seem that the old code works, but since ElasticSearch does try to find the non-existing field for each document this has a huge performance impact. On a small test index it almost doubles the time it takes to perform the query (45ms vs the original 82ms (average of 10 requests)).


