### PR TITLE
Executes are repeatedly executed in the loop body. Actions are not re…

### DIFF
--- a/BulkCommand.php
+++ b/BulkCommand.php
@@ -78,7 +78,7 @@ class BulkCommand extends Component
         } else {
             $body = $this->actions;
         }
-
+        $this->actions = null;
         return $this->db->post($endpoint, $this->options, $body);
     }
 


### PR DESCRIPTION
…leased, resulting in duplicate actions. Memory growth causes the program to crash.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any


![image](https://user-images.githubusercontent.com/5868671/122319378-24b4dc80-cf53-11eb-945c-0e24653ec0cc.png)
