### PR TITLE
Added Runtime Mappings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
           - "7.4"
 
         es-version:
+          - "7.14.0"
           - "7.7.0"
           - "6.8.9"
           - "5.6.16"
@@ -67,7 +68,7 @@ jobs:
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-        
+
       - name: Cache dependencies installed with composer
         uses: actions/cache@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Elasticsearch extension Change Log
 2.1.3 under development
 -----------------------
 
-- no changes in this release.
+- Enh #311: Added support for runtime mappings in Elasticsearch 7.11+ (mabentley85)
 
 
 2.1.2 August 09, 2021

--- a/Query.php
+++ b/Query.php
@@ -123,7 +123,7 @@ class Query extends Component implements QueryInterface
      * ```
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-mapping-fields.html
-     * @see $runtimeMappings()
+     * @see runtimeMappings()
      * @see source
      */
     public $runtimeMappings;

--- a/Query.php
+++ b/Query.php
@@ -104,6 +104,28 @@ class Query extends Component implements QueryInterface
      */
     public $scriptFields;
     /**
+     * @var array A runtime field is a field that is evaluated at query time
+     * Example:
+     * ```php
+     * $query->$runtimeMappings = [
+     *     'value_times_two' => [
+     *         'script' => "emit(doc['my_field_name'].value * 2)",
+     *     ],
+     *     'value_times_factor' => [
+     *         'script' => "emit(doc['my_field_name'].value * factor)",
+     *         'params' => [
+     *             'factor' => 2.0
+     *         ],
+     *     ],
+     * ]
+     * ```
+     *
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime.html
+     * @see $runtimeMappings()
+     * @see source
+     */
+    public $runtimeMappings;
+    /**
      * @var array this option controls how the `_source` field is returned from
      * the documents. For example, `['id', 'name']` means that only the `id`
      * and `name` field should be returned from `_source`.  If not set, it
@@ -450,7 +472,7 @@ class Query extends Component implements QueryInterface
         if ($this->emulateExecution) {
             return 0;
         }
-        
+
         $command = $this->createCommand($db);
 
         // performing a query with return size of 0, is equal to getting result stats such as count
@@ -728,6 +750,22 @@ class Query extends Component implements QueryInterface
             $this->scriptFields = $fields;
         } else {
             $this->scriptFields = func_get_args();
+        }
+        return $this;
+    }
+
+    /**
+     * Sets the runtime mappings for this query
+     * @param $mappings
+     * @return $this the query object itself
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime.html
+     */
+    public function runtimeMappings($mappings)
+    {
+        if (is_array($mappings) || $mappings === null) {
+            $this->runtimeMappings = $mappings;
+        } else {
+            $this->runtimeMappings = func_get_args();
         }
         return $this;
     }

--- a/Query.php
+++ b/Query.php
@@ -109,9 +109,11 @@ class Query extends Component implements QueryInterface
      * ```php
      * $query->$runtimeMappings = [
      *     'value_times_two' => [
+     *         'type' => 'double',
      *         'script' => "emit(doc['my_field_name'].value * 2)",
      *     ],
      *     'value_times_factor' => [
+     *         'type' => 'double',
      *         'script' => "emit(doc['my_field_name'].value * factor)",
      *         'params' => [
      *             'factor' => 2.0
@@ -120,11 +122,19 @@ class Query extends Component implements QueryInterface
      * ]
      * ```
      *
-     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-mapping-fields.html
      * @see $runtimeMappings()
      * @see source
      */
     public $runtimeMappings;
+    /**
+     * @var array Use the fields parameter to retrieve the values of runtime fields.  Runtime fields won’t display in
+     * _source, but the fields API works for all fields, even those that were not sent as part of the original _source.
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-retrieving-fields.html
+     * @see fields()
+     * @see fields
+     */
+    public $fields;
     /**
      * @var array this option controls how the `_source` field is returned from
      * the documents. For example, `['id', 'name']` means that only the `id`
@@ -766,6 +776,22 @@ class Query extends Component implements QueryInterface
             $this->runtimeMappings = $mappings;
         } else {
             $this->runtimeMappings = func_get_args();
+        }
+        return $this;
+    }
+
+    /**
+     * Sets the runtime fields to retrieve from the documents.
+     * @param array $fields the fields to be selected.
+     * @return $this the query object itself
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-retrieving-fields.html
+     */
+    public function fields($fields)
+    {
+        if (is_array($fields) || $fields === null) {
+            $this->fields = $fields;
+        } else {
+            $this->fields = func_get_args();
         }
         return $this;
     }

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -56,6 +56,9 @@ class QueryBuilder extends BaseObject
         if ($query->runtimeMappings !== null) {
             $parts['runtime_mappings'] = $query->runtimeMappings;
         }
+        if ($query->fields !== null) {
+            $parts['fields'] = $query->fields;
+        }
 
         if ($query->source !== null) {
             $parts['_source'] = $query->source;

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -53,6 +53,9 @@ class QueryBuilder extends BaseObject
         if ($query->scriptFields !== null) {
             $parts['script_fields'] = $query->scriptFields;
         }
+        if ($query->runtimeMappings !== null) {
+            $parts['runtime_mappings'] = $query->runtimeMappings;
+        }
 
         if ($query->source !== null) {
             $parts['_source'] = $query->source;

--- a/docs/guide/usage-query.md
+++ b/docs/guide/usage-query.md
@@ -94,3 +94,30 @@ $query->from('customer');
 // Note the literal string 'true', not a boolean value!
 $query->addOptions(['track_total_hits' => 'true']);
 ```
+
+## Runtime Fields/Mappings in ES >= 7.11
+
+Runtime Fields are fields that can be dynamically generated at query time by supplying a script similar to `script_fields`.
+The major difference being that the value of a Runtime Field can be used in search queries, aggregations, filtering, and 
+sorting.
+
+Any Runtime Field values that you want to be included in the search results must be added to the `field` array by passing
+an array of field names using the `fields()` method. 
+
+Example for fetching users' full names by concatenating the `first_name` and `last_name` fields from the index and 
+sorting them alphabetically.
+```php
+$results = (new yii\elasticsearch\Query())
+    ->from('users')
+    ->runtimeMappings([
+        'full_name' => [
+            'type' => 'keyword',
+            'script' => "emit(doc['first_name'].value + ' ' + doc['last_name'].value)",
+        ],
+    ])
+    ->fields(['full_name'])
+    ->orderBy(['full_name' => SORT_ASC])
+    ->search($connection);
+```
+
+For more information concerning `type` and `script` please see [Elastic's Runtime Field Documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime.html)

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -451,4 +451,30 @@ class QueryTest extends TestCase
 
         $this->assertCount(5, $result['customer_name'][0]['options']);
     }
+
+    public function testRuntimeMappings()
+    {
+        $query = new Query();
+        $query->from('query-test', 'user');
+
+        $query->runtimeMappings([
+            'name_email' => [
+                'type' => 'keyword',
+                'script' => "emit(doc['name'].value + ':' + doc['email'].value)",
+            ],
+        ]);
+        $this->assertEquals([
+            'name_email' => [
+                'type' => 'keyword',
+                'script' => "emit(doc['name'].value + ':' + doc['email'].value)",
+            ],
+        ], $query->runtimeMappings);
+
+        $query->fields(['name_email']);
+        $this->assertEquals(['name_email'], $query->fields);
+
+        $result = $query->search($this->getConnection());
+        $this->assertArrayHasKey('name_email', $result['hits']['hits'][0]['fields']);
+        $this->assertEquals($result['hits']['hits'][0]['fields']['name_email'][0], 'user1:user1@example.com');
+    }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -454,20 +454,9 @@ class QueryTest extends TestCase
 
     public function testRuntimeMappings()
     {
-        // Check Elasticsearch version
+        // Check that Elasticsearch is version 7.11.0 or later before running this test
         $elasticsearchInfo = $this->getConnection()->get('/');
-        preg_match('/^(\d+)\.(\d+)\.(\d+)$/', $elasticsearchInfo['version']['number'], $matches);
-
-        if (empty($matches) || count($matches) < 4) {
-            return;
-        }
-
-        // Runtime Mappings require Elasticsearch Version 7.11 or newer
-        if (intval($matches[1]) < 7) {
-            return;
-        }
-
-        if (intval($matches[2]) < 11) {
+        if(!version_compare($elasticsearchInfo['version']['number'], '7.11.0', '>=')) {
             return;
         }
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -454,6 +454,23 @@ class QueryTest extends TestCase
 
     public function testRuntimeMappings()
     {
+        // Check Elasticsearch version
+        $elasticsearchInfo = $this->getConnection()->get('/');
+        preg_match('/^(\d+)\.(\d+)\.(\d+)$/', $elasticsearchInfo['version']['number'], $matches);
+
+        if (empty($matches) || count($matches) < 4) {
+            return;
+        }
+
+        // Runtime Mappings require Elasticsearch Version 7.11 or newer
+        if (intval($matches[1]) < 7) {
+            return;
+        }
+
+        if (intval($matches[2]) < 11) {
+            return;
+        }
+
         $query = new Query();
         $query->from('query-test', 'user');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no? Requires Elasticsearch version 7.11 or higher 
| Tests pass?   | yes

Added query config to support [Runtime Fields/Mappings](https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime.html) in Elasticsearch 7.11 and newer.