### PR TITLE
Elasticsearch 8.x compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
           - "7.4"
 
         es-version:
+          - "8.1.3"
           - "7.14.0"
           - "7.7.0"
           - "6.8.9"
@@ -36,6 +37,8 @@ jobs:
         env:
           "transport.host": "127.0.0.1"
           "http.publish_host": "127.0.0.1"
+          "xpack.security.enabled": "false"
+          "indices.id_field_data.enabled": "true"
         ports:
           - 9200:9200
 

--- a/Command.php
+++ b/Command.php
@@ -202,7 +202,7 @@ class Command extends Component
         $body = Json::encode(['ids' => array_values($ids)]);
 
         if ($this->db->dslVersion >= 7) {
-            return $this->db->get([$index, '_doc', '_mget'], $options, $body);
+            return $this->db->get([$index, '_mget'], $options, $body);
         } else {
             return $this->db->get([$index, $type, '_mget'], $options, $body);
         }
@@ -289,7 +289,7 @@ class Command extends Component
         }
 
         if ($this->db->dslVersion >= 7) {
-            return $this->db->post([$index, '_doc', $id, '_update'], $options, Json::encode($body));
+            return $this->db->post([$index, '_update', $id], $options, Json::encode($body));
         } else {
             return $this->db->post([$index, $type, $id, '_update'], $options, Json::encode($body));
         }

--- a/ElasticsearchTarget.php
+++ b/ElasticsearchTarget.php
@@ -78,7 +78,11 @@ class ElasticsearchTarget extends Target
     {
         $messages = array_map([$this, 'prepareMessage'], $this->messages);
         $body = implode("\n", $messages) . "\n";
-        $this->db->post([$this->index, $this->type, '_bulk'], $this->options, $body);
+        if ($this->db->dslVersion >= 7) {
+            $this->db->post([$this->index, '_bulk'], $this->options, $body);
+        } else {
+            $this->db->post([$this->index, $this->type, '_bulk'], $this->options, $body);
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
Fixes | https://github.com/yiisoft/yii2-elasticsearch/issues/319
Related to | https://github.com/yiisoft/yii2-elasticsearch/pull/320

The tests on 6.8.9 fail, because elasticsearch does not recognize `indices.id_field_data.enabled` setting, which is needed because on 8.x you can no longer use `_id` to sort, unless you activate this setting. I'm open to suggestions :)

Also, I changed the commit from https://github.com/yiisoft/yii2-elasticsearch/pull/320 to check for `dslVersion >= 7` , as on version `7` the calls were deprecated anyway.
