### PR TITLE
Curl options config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 Elasticsearch extension Change Log
 
 2.1.4 under development
 -----------------------
-
+- Enh #329: Added `curlOptions` attribute for advanced configuration of curl session (yuniorsk)
 
 2.1.3 August 07, 2022
 -----------------------

--- a/Connection.php
+++ b/Connection.php
@@ -97,6 +97,7 @@ class Connection extends Component
     public $dataTimeout = null;
     /**
      * @var array additional options used to configure curl session
+     * @since 2.1.4
      */
     public $curlOptions = [];
     /**

--- a/Connection.php
+++ b/Connection.php
@@ -96,6 +96,10 @@ class Connection extends Component
      */
     public $dataTimeout = null;
     /**
+     * @var array additional options used to configure curl session
+     */
+    public $curlOptions = [];
+    /**
      * @var integer version of the domain-specific language to use with the server.
      * This must be set to the major version of the Elasticsearch server in use, e.g. `5` for Elasticsearch 5.x.x,
      * `6` for Elasticsearch 6.x.x, and `7` for Elasticsearch 7.x.x.
@@ -453,6 +457,10 @@ class Connection extends Component
             CURLOPT_CUSTOMREQUEST  => $method,
             CURLOPT_FORBID_REUSE   => false,
         ];
+
+        if (!empty($this->curlOptions)) {
+            $options = array_merge($options, $this->curlOptions);
+        }
 
         if (!empty($this->auth) || isset($this->nodes[$this->activeNode]['auth']) && $this->nodes[$this->activeNode]['auth'] !== false) {
             $auth = isset($this->nodes[$this->activeNode]['auth']) ? $this->nodes[$this->activeNode]['auth'] : $this->auth;

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,11 @@
     "autoload": {
         "psr-4": { "yii\\elasticsearch\\": "" }
     },
+    "config": {
+        "allow-plugins": {
+            "yiisoft/yii2-composer": true
+        }
+    },
     "repositories": [
        {
            "type": "composer",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | 

Hi, in elasticsearch is enabled security by default since version 8.0, but there's no way to configure this client to make it work. So I added extra attribute to allow further configuration of curl session. I considered adding new attribute per curl option, but this way is more flexible.