### PR TITLE
Fix curlOptions merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Elasticsearch extension Change Log
 2.1.4 under development
 -----------------------
 - Enh #329: Added `curlOptions` attribute for advanced configuration of curl session (yuniorsk)
-- Bug #330: Fix `curlOptions` merging
+- Bug #330: Fix `curlOptions` merging (yuniorsk)
 
 2.1.3 August 07, 2022
 -----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Elasticsearch extension Change Log
 2.1.4 under development
 -----------------------
 - Enh #329: Added `curlOptions` attribute for advanced configuration of curl session (yuniorsk)
+- Bug #330: Fix `curlOptions` merging
 
 2.1.3 August 07, 2022
 -----------------------

--- a/Connection.php
+++ b/Connection.php
@@ -459,8 +459,8 @@ class Connection extends Component
             CURLOPT_FORBID_REUSE   => false,
         ];
 
-        if (!empty($this->curlOptions)) {
-            $options = array_merge($options, $this->curlOptions);
+        foreach ($this->curlOptions as $key => $value) {
+            $options[$key] = $value;
         }
 
         if (!empty($this->auth) || isset($this->nodes[$this->activeNode]['auth']) && $this->nodes[$this->activeNode]['auth'] !== false) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |  #329, #330 

Fix curl options merging as integer keys are discarded with `array_merge`
