### PR TITLE
Fix #332 added [\ReturnTypeWillChange] attribute for BatchQueryResult…

### DIFF
--- a/BatchQueryResult.php
+++ b/BatchQueryResult.php
@@ -7,6 +7,7 @@
 
 namespace yii\elasticsearch;
 
+use ReturnTypeWillChange;
 use yii\base\BaseObject;
 
 /**
@@ -111,6 +112,7 @@ class BatchQueryResult extends BaseObject implements \Iterator
      * Resets the iterator to the initial state.
      * This method is required by the interface [[\Iterator]].
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->reset();
@@ -121,6 +123,7 @@ class BatchQueryResult extends BaseObject implements \Iterator
      * Moves the internal pointer to the next dataset.
      * This method is required by the interface [[\Iterator]].
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         if ($this->_batch === null || !$this->each || $this->each && next($this->_batch) === false) {
@@ -183,6 +186,7 @@ class BatchQueryResult extends BaseObject implements \Iterator
      * This method is required by the interface [[\Iterator]].
      * @return int the index of the current row.
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->_key;
@@ -193,6 +197,7 @@ class BatchQueryResult extends BaseObject implements \Iterator
      * This method is required by the interface [[\Iterator]].
      * @return mixed the current dataset.
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->_value;
@@ -203,6 +208,7 @@ class BatchQueryResult extends BaseObject implements \Iterator
      * This method is required by the interface [[\Iterator]].
      * @return bool whether there is a valid dataset at the current position.
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return !empty($this->_batch);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 Elasticsearch extension Change Log
 -----------------------
 - Enh #329: Added `curlOptions` attribute for advanced configuration of curl session (yuniorsk)
 - Bug #330: Fix `curlOptions` merging (yuniorsk)
+- Bug #332: Added `[\ReturnTypeWillChange]` attribute for BatchQueryResult methods to be compatible with Iterator interface (warton)
 
 2.1.3 August 07, 2022
 -----------------------


### PR DESCRIPTION
Added [\ReturnTypeWillChange] attribute for BatchQueryResult methods that are incompatible with Iterator interface (rewind, next, key, current, valid)

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #332 
