### PR TITLE
Fix ES exception when a field missed in using `updateAllCounters`.

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -252,7 +252,7 @@ class ActiveRecord extends BaseActiveRecord
      * @param mixed $value
      * @throws \yii\base\InvalidCallException when record is not new
      * @deprecated since 2.1.0
-     */0
+     */
     public function setPrimaryKey($value)
     {
         $pk = static::primaryKey()[0];

--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -252,7 +252,7 @@ class ActiveRecord extends BaseActiveRecord
      * @param mixed $value
      * @throws \yii\base\InvalidCallException when record is not new
      * @deprecated since 2.1.0
-     */
+     */0
     public function setPrimaryKey($value)
     {
         $pk = static::primaryKey()[0];
@@ -720,7 +720,7 @@ class ActiveRecord extends BaseActiveRecord
         foreach ($primaryKeys as $pk) {
             $script = '';
             foreach ($counters as $counter => $value) {
-                $script .= "ctx._source.{$counter} += params.{$counter};\n";
+                $script .= "ctx._source.{$counter} = (ctx._source.{$counter} == null ? 0 : ctx._source.{$counter}) +  params.{$counter};\n";
             }
             $bulkCommand->addAction(["update" => ["_id" => $pk]], [
                 'script' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

When using `updateAllCounters` for a field which is missed or is null get exception error from `ElasticSearch`:

```
Cannot invoke "Object.getClass()" because "left" is null
```

This behavior should cast null and missed field to `0`.