### PR TITLE
Disable JSON pretty print for ElasticSearch bulk API

### DIFF
--- a/BulkCommand.php
+++ b/BulkCommand.php
@@ -72,8 +72,16 @@ class BulkCommand extends Component
             $body = '{}';
         } elseif (is_array($this->actions)) {
             $body = '';
+            $prettyPrintSupport = property_exists('yii\\helpers\\Json', 'prettyPrint');
+            if ($prettyPrintSupport) {
+                $originalPrettyPrint = Json::$prettyPrint;
+                Json::$prettyPrint = false; // ElasticSearch bulk API uses new lines as delimiters.
+            }
             foreach ($this->actions as $action) {
                 $body .= Json::encode($action) . "\n";
+            }
+            if ($prettyPrintSupport) {
+                Json::$prettyPrint = $originalPrettyPrint;
             }
         } else {
             $body = $this->actions;

--- a/BulkCommand.php
+++ b/BulkCommand.php
@@ -72,15 +72,15 @@ class BulkCommand extends Component
             $body = '{}';
         } elseif (is_array($this->actions)) {
             $body = '';
-            $prettyPrintSupport = property_exists('yii\\helpers\\Json', 'prettyPrint');
-            if ($prettyPrintSupport) {
+            $prettyPrintSupported = property_exists('yii\\helpers\\Json', 'prettyPrint');
+            if ($prettyPrintSupported) {
                 $originalPrettyPrint = Json::$prettyPrint;
                 Json::$prettyPrint = false; // ElasticSearch bulk API uses new lines as delimiters.
             }
             foreach ($this->actions as $action) {
                 $body .= Json::encode($action) . "\n";
             }
-            if ($prettyPrintSupport) {
+            if ($prettyPrintSupported) {
                 Json::$prettyPrint = $originalPrettyPrint;
             }
         } else {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Elasticsearch extension Change Log
 2.1.5 under development
 -----------------------
 
-- no changes in this release.
+- Bug #344: Disabled JSON pretty print for ElasticSearch bulk API (rhertogh)
 
 
 2.1.4 May 22, 2023


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

This PR disables JSON pretty print for ElasticSearch bulk API since it uses new lines as delimiter.
From the [ElasticSearch bulk API documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#:~:text=Because%20this%20format%20uses%20literal%20%5Cn%27s%20as%20delimiters%2C%20make%20sure%20that%20the%20JSON%20actions%20and%20sources%20are%20not%20pretty%20printed.):
> Because this format uses literal \n's as delimiters, make sure that the JSON actions and sources are not pretty printed.

