### PR TITLE
Fix #352: Add support for query parameter `search_after` to paginate over large datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Elasticsearch extension Change Log
 
 - Bug #344: Disabled JSON pretty print for ElasticSearch bulk API (rhertogh)
 - Bug #350: Remove deprecated code, set $pagination->totalCount (lav45)
+- Bug #352: Add support for query parameter `search_after` to paginate over large datasets (lubosdz)
 
 
 2.1.4 May 22, 2023

--- a/src/Query.php
+++ b/src/Query.php
@@ -237,7 +237,7 @@ class Query extends Component implements QueryInterface
      */
     public $explain;
     /**
-     * @var array Allows pagination on larget datasets.
+     * @var array Allows pagination of large datasets.
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after
      * @since 2.1.5
      */

--- a/src/Query.php
+++ b/src/Query.php
@@ -236,6 +236,12 @@ class Query extends Component implements QueryInterface
      * @since 2.0.5
      */
     public $explain;
+    /**
+     * @var array Allows pagination on larget datasets.
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after
+     * @since 2.1.5
+     */
+    public $search_after = [];
 
 
     /**

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -109,6 +109,9 @@ class QueryBuilder extends BaseObject
         if (!empty($query->collapse)) {
             $parts['collapse'] = $query->collapse;
         }
+        if ($query->search_after) {
+            $parts['search_after'] = $query->search_after;
+        }
 
         $sort = $this->buildOrderBy($query->orderBy);
         if (!empty($sort)) {


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #352 
