### PR TITLE
Fix #367: Add missing `@property` annotations in `Command`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Yii Framework 2 Elasticsearch extension Change Log
 - Enh #358: Applying Yii2 coding standards (@s1lver)
 - Enh #358: Raise min version to PHP 7.4 (@s1lver)
 - Bug #355: `ActiveDataProvider` pagination issue where `totalCount` returned 0 after updating from 2.1.5 to 2.1.6, causing incorrect `X-Pagination-Total-Count` header serialization (@lav45)
-- Bug #TBD: Fix `@property` annotations in `Command` (mspirkov)
+- Bug #367: Add missing `@property` annotations in `Command` (mspirkov)
 
 
 2.1.5 February 13, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 Elasticsearch extension Change Log
 - Enh #358: Applying Yii2 coding standards (@s1lver)
 - Enh #358: Raise min version to PHP 7.4 (@s1lver)
 - Bug #355: `ActiveDataProvider` pagination issue where `totalCount` returned 0 after updating from 2.1.5 to 2.1.6, causing incorrect `X-Pagination-Total-Count` header serialization (@lav45)
+- Bug #TBD: Fix `@property` annotations in `Command` (mspirkov)
 
 
 2.1.5 February 13, 2025

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -739,6 +739,12 @@ parameters:
 			path: src/BulkCommand.php
 
 		-
+			message: '#^Class yii\\elasticsearch\\Command has PHPDoc tag @property\-read for property \$aliasInfo with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Command.php
+
+		-
 			message: '#^Method yii\\elasticsearch\\Command\:\:addAlias\(\) has parameter \$aliasParameters with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -1768,12 +1774,6 @@ parameters:
 			message: '#^Property yii\\elasticsearch\\Query\:\:\$type type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: src/Query.php
-
-		-
-			message: '#^Result of \|\| is always true\.$#'
-			identifier: booleanOr.alwaysTrue
-			count: 3
 			path: src/Query.php
 
 		-

--- a/src/Command.php
+++ b/src/Command.php
@@ -19,6 +19,11 @@ use yii\helpers\Json;
  * Check the [Elasticsearch guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html)
  * for details on these commands.
  *
+ * @property-read array $aliasInfo
+ * @property-read mixed $indexRecoveryStats
+ * @property-read mixed $indexStats
+ * @property-read mixed $mapping
+ *
  * @author Carsten Brandt <mail@cebe.cc>
  * @since 2.0
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

See: https://github.com/yiisoft/yii2/pull/21042